### PR TITLE
Allow skipping hosting/proxy check for passport trusted wallets

### DIFF
--- a/faucet-client/src/common/FaucetApi.ts
+++ b/faucet-client/src/common/FaucetApi.ts
@@ -119,21 +119,24 @@ export class FaucetApi {
     return this.apiGet("/getFaucetStatus");
   }
 
-  public getPassportInfo(sessionId: string): Promise<IPassportInfo> {
+  public getPassportInfo(sessionId: string, address: string): Promise<IPassportInfo> {
     return this.apiGet("/getPassportInfo", {
-      session: sessionId
+      session: sessionId,
+      address: address,
     });
   }
 
-  public refreshPassport(sessionId: string): Promise<IPassportInfo> {
+  public refreshPassport(sessionId: string, address: string): Promise<IPassportInfo> {
     return this.apiGet("/refreshPassport", {
-      session: sessionId
+      session: sessionId,
+      address: address,
     });
   }
 
-  public refreshPassportJson(sessionId: string, json: string): Promise<IPassportInfo> {
+  public refreshPassportJson(sessionId: string, address: string, json: string): Promise<IPassportInfo> {
     return this.apiPost("/refreshPassport", {
-      session: sessionId
+      session: sessionId,
+      address: address,
     }, json);
   }
 

--- a/faucet-client/src/common/FaucetConfig.ts
+++ b/faucet-client/src/common/FaucetConfig.ts
@@ -106,6 +106,8 @@ export interface IPassportModuleConfig {
   manualVerification: boolean;
   stampScoring: {[stamp: string]: number};
   boostFactor: {[score: number]: number};
+  overrideScores: [number, number];
+  guestRefresh: number | boolean;
 }
 
 

--- a/faucet-client/src/common/FaucetSession.ts
+++ b/faucet-client/src/common/FaucetSession.ts
@@ -38,6 +38,7 @@ export interface IFaucetSessionInfo {
   modules?: {[module: string]: any};
   failedCode?: string;
   failedReason?: string;
+  failedData?: {[key: string]: any};
 }
 
 export interface IFaucetSessionRecoveryInfo {

--- a/faucet-client/src/components/frontpage/FrontPage.tsx
+++ b/faucet-client/src/components/frontpage/FrontPage.tsx
@@ -6,6 +6,7 @@ import { FaucetInput } from './FaucetInput';
 import { IFaucetContext } from '../../common/FaucetContext';
 import { FaucetSession } from '../../common/FaucetSession';
 import { RestoreSession } from './RestoreSession';
+import { PassportInfo } from '../passport/PassportInfo';
 
 export interface IFrontPageProps {
   faucetContext: IFaucetContext;
@@ -102,8 +103,65 @@ export class FrontPage extends React.PureComponent<IFrontPageProps, IFrontPageSt
   private async onSubmitInputs(inputData: any): Promise<void> {
     try {
       let sessionInfo = await this.props.faucetContext.faucetApi.startSession(inputData);
-      if(sessionInfo.status === "failed")
+      if(sessionInfo.status === "failed") {
+        if(sessionInfo.failedCode == "IPINFO_RESTRICTION" && this.props.faucetConfig.modules["passport"] && this.props.faucetConfig.modules["passport"].guestRefresh !== false && sessionInfo.failedData["ipflags"]) {
+          let canStartWithScore = false;
+          let requiredScore = 0;
+          let ipflags: string[] = [];
+
+          if(sessionInfo.failedData["ipflags"][0] && this.props.faucetConfig.modules["passport"].overrideScores[0] > 0) {
+            canStartWithScore = true;
+            ipflags.push("hosting");
+            if(this.props.faucetConfig.modules["passport"].overrideScores[0] > requiredScore)
+              requiredScore = this.props.faucetConfig.modules["passport"].overrideScores[0];
+          }
+          if(sessionInfo.failedData["ipflags"][1] && this.props.faucetConfig.modules["passport"].overrideScores[1] > 0) {
+            canStartWithScore = true;
+            ipflags.push("proxy");
+            if(this.props.faucetConfig.modules["passport"].overrideScores[1] > requiredScore)
+              requiredScore = this.props.faucetConfig.modules["passport"].overrideScores[1];
+          }
+
+          if(canStartWithScore) {
+            // special case, the session is denied as the users IP is flagged as hosting/proxy range.
+            // however, the faucet allows skipping this check for passport trusted wallets
+            // show a dialog that shows the score & allows refreshing the passport to meet the requirement
+
+
+            this.props.faucetContext.showDialog({
+              title: "Could not start session",
+              size: "lg",
+              body: (
+                <div className='passport-dialog error-dialog'>
+                  <PassportInfo 
+                    pageContext={this.props.faucetContext}
+                    faucetConfig={this.props.faucetConfig}
+                    targetAddr={sessionInfo.failedData["address"]}
+                    refreshFn={(passportScore) => {
+                      
+                    }}
+                  >
+                    <div>
+                      <div className='alert alert-danger'>The faucet denied starting a session because your IP Address is marked as {ipflags.join(" and ")} range.</div>
+                      <div className="boost-descr">
+                        However, you can verify your unique identity using <a href="https://passport.gitcoin.co/#/dashboard" target="_blank">Gitcoin Passport</a>.
+                      </div>
+                      <div className="boost-descr2">
+                        Ensure your provided address achieves a minimum score of {requiredScore} to bypass the IP check and initiate a session.
+                      </div>
+                    </div>
+                  </PassportInfo>
+                </div>
+              ),
+              closeButton: { caption: "Close" },
+            });
+
+            throw null; // throw without dialog
+          }
+        }
+
         throw (sessionInfo.failedCode ? "[" + sessionInfo.failedCode + "] " : "") + sessionInfo.failedReason;
+      }
 
       let session = new FaucetSession(this.props.faucetContext, sessionInfo.session, sessionInfo);
       this.props.faucetContext.activeSession = session;
@@ -129,11 +187,13 @@ export class FrontPage extends React.PureComponent<IFrontPageProps, IFrontPageSt
           throw "unexpected session state";
       }
     } catch(ex) {
-      this.props.faucetContext.showDialog({
-        title: "Could not start session",
-        body: (<div className='alert alert-danger'>{ex.toString()}</div>),
-        closeButton: { caption: "Close" },
-      });
+      if(ex) {
+        this.props.faucetContext.showDialog({
+          title: "Could not start session",
+          body: (<div className='alert alert-danger'>{ex.toString()}</div>),
+          closeButton: { caption: "Close" },
+        });
+      }
       throw ex;
     }
   }

--- a/faucet-client/src/components/passport/PassportInfo.css
+++ b/faucet-client/src/components/passport/PassportInfo.css
@@ -46,6 +46,11 @@
   white-space: pre;
 }
 
+.pow-boost-info .passport-details {
+  max-height: 600px;
+  overflow-x: auto;
+}
+
 .pow-boost-info .passport-details .row.details-header > div {
   padding: 0;
   font-weight: 600;

--- a/faucet-client/src/components/passport/PassportInfo.tsx
+++ b/faucet-client/src/components/passport/PassportInfo.tsx
@@ -8,10 +8,11 @@ import "./PassportInfo.css";
 
 export interface IPassportInfoProps {
   targetAddr: string;
-  sessionId: string;
+  sessionId?: string;
   faucetConfig: IFaucetConfig;
   pageContext: IFaucetContext;
   refreshFn: (score: IPassportScoreInfo) => void;
+  children?: React.ReactElement;
 }
 
 export interface IPassportInfoState {
@@ -64,7 +65,7 @@ export class PassportInfo extends React.PureComponent<IPassportInfoProps, IPassp
     });
 
     try {
-      let passportInfo = await this.props.pageContext.faucetApi.getPassportInfo(this.props.sessionId);
+      let passportInfo = await this.props.pageContext.faucetApi.getPassportInfo(this.props.sessionId, this.props.targetAddr);
       this.setState({
         loadingPassport: false,
         passportInfo: passportInfo,
@@ -107,7 +108,10 @@ export class PassportInfo extends React.PureComponent<IPassportInfoProps, IPassp
 
     return (
       <div className="pow-boost-info">
-        <div className="boost-descr">Increase your passport score by verifying stamps on your <a href="https://passport.gitcoin.co/#/dashboard" target="_blank">Gitcoin Passport</a>.</div>
+        {this.props.children ?
+          this.props.children :
+          <div className="boost-descr">Increase your passport score by verifying stamps on your <a href="https://passport.gitcoin.co/#/dashboard" target="_blank">Gitcoin Passport</a>.</div>
+        }
         <div className="boost-passport">
           <div className="passport-summary container">
             <div className="row">
@@ -158,7 +162,7 @@ export class PassportInfo extends React.PureComponent<IPassportInfoProps, IPassp
                   onClick={(evt) => this.onRefreshPassportClick()} 
                   disabled={this.state.refreshCooldownSec > 0 || this.state.refreshProcessing || this.state.manualRefreshRunning}
                   >
-                    Refresh Passport Automatically{this.state.refreshCooldownSec > 0 ? " (" + this.state.refreshCooldownSec + ")" : ""}
+                    Refresh Passport {this.state.refreshCooldownSec > 0 ? " (" + this.state.refreshCooldownSec + ")" : ""}
                 </button>
               </div>
               {this.props.faucetConfig.modules["passport"].manualVerification ?
@@ -335,7 +339,7 @@ export class PassportInfo extends React.PureComponent<IPassportInfoProps, IPassp
       showRefreshForm: false,
     });
     
-    this.props.pageContext.faucetApi.refreshPassport(this.props.sessionId).then((res: any) => {
+    this.props.pageContext.faucetApi.refreshPassport(this.props.sessionId, this.props.targetAddr).then((res: any) => {
       if(res.error)
         throw res;
       
@@ -378,7 +382,7 @@ export class PassportInfo extends React.PureComponent<IPassportInfoProps, IPassp
       manualRefreshRunning: true,
     });
 
-    this.props.pageContext.faucetApi.refreshPassportJson(this.props.sessionId, this.state.passportJson).then((res: any) => {
+    this.props.pageContext.faucetApi.refreshPassportJson(this.props.sessionId, this.props.targetAddr, this.state.passportJson).then((res: any) => {
       if(res.error)
         throw res;
       

--- a/faucet-config.example.yaml
+++ b/faucet-config.example.yaml
@@ -354,6 +354,11 @@ modules:
 
     stampDeduplicationTime: 604800 # allow reusing a stamp in another passport after 7 days
 
+    skipProxyCheckScore: 0  # skip proxy check for IP when wallet score exceeds this
+    skipHostingCheckScore: 0 # skip hosting check for IP when wallet score exceeds this
+    allowGuestRefresh: false # allow passport refresh without active session (ie. refresh for skippimg hosting/proxy check)
+    guestRefreshCooldown: 0 # refresh cooldown without active session (default to refreshCooldown if 0)
+
     boostFactor:
       1: 1.1 # x1.1 if score >= 1
       5: 1.5 # x1.5 if score >= 5

--- a/src/common/FaucetError.ts
+++ b/src/common/FaucetError.ts
@@ -1,6 +1,7 @@
 
 export class FaucetError extends Error {
   private code: string;
+  public data: {[key: string]: any};
 
   public constructor(code: string, message: string) {
     super(message);

--- a/src/modules/MODULE_HOOKS.md
+++ b/src/modules/MODULE_HOOKS.md
@@ -7,7 +7,8 @@ SessionStart
     prio 2: whitelist, zupass
     prio 3: ensname
     prio 5: *eth_address_check
-    prio 6: concurrency-limit, ethinfo, ipinfo, mainnet-wallet, passport, recurring-limits
+    prio 6: passport
+    prio 7: concurrency-limit, ethinfo, ipinfo, mainnet-wallet, recurring-limits
     prio 10: pow
 
 SessionRestore

--- a/src/modules/concurrency-limit/ConcurrencyLimitModule.ts
+++ b/src/modules/concurrency-limit/ConcurrencyLimitModule.ts
@@ -11,7 +11,7 @@ export class ConcurrencyLimitModule extends BaseModule<IConcurrencyLimitConfig> 
 
   protected override startModule(): Promise<void> {
     this.moduleManager.addActionHook(
-      this, ModuleHookAction.SessionStart, 6, "Recurring limits check", 
+      this, ModuleHookAction.SessionStart, 7, "Recurring limits check", 
       (session: FaucetSession) => this.processSessionStart(session)
     );
     this.moduleManager.addActionHook(

--- a/src/modules/ethinfo/EthInfoModule.ts
+++ b/src/modules/ethinfo/EthInfoModule.ts
@@ -10,7 +10,7 @@ export class EthInfoModule extends BaseModule<IEthInfoConfig> {
   protected readonly moduleDefaultConfig = defaultConfig;
 
   protected override startModule(): Promise<void> {
-    this.moduleManager.addActionHook(this, ModuleHookAction.SessionStart, 6, "ETH Info check", (session: FaucetSession, userInput: any) => this.processSessionStart(session, userInput));
+    this.moduleManager.addActionHook(this, ModuleHookAction.SessionStart, 7, "ETH Info check", (session: FaucetSession, userInput: any) => this.processSessionStart(session, userInput));
     return Promise.resolve();
   }
 

--- a/src/modules/ipinfo/IPInfoModule.ts
+++ b/src/modules/ipinfo/IPInfoModule.ts
@@ -35,7 +35,7 @@ export class IPInfoModule extends BaseModule<IIPInfoConfig> {
     this.ipInfoDb = await ServiceManager.GetService(FaucetDatabase).createModuleDb(IPInfoDB, this);
     this.ipInfoResolver = new IPInfoResolver(this.ipInfoDb, this.moduleConfig.apiUrl);
     this.moduleManager.addActionHook(
-      this, ModuleHookAction.SessionStart, 6, "IP Info check", 
+      this, ModuleHookAction.SessionStart, 7, "IP Info check", 
       (session: FaucetSession) => this.processSessionStart(session)
     );
     this.moduleManager.addActionHook(
@@ -73,6 +73,17 @@ export class IPInfoModule extends BaseModule<IIPInfoConfig> {
       if(this.moduleConfig.required)
         throw new FaucetError("INVALID_IPINFO", "Error while checking your IP: " + ex.toString());
     }
+
+    let overrideHosting = session.getSessionData<boolean>("ipinfo.override_hosting", undefined);
+    if(overrideHosting !== undefined) {
+      ipInfo.hosting = overrideHosting;
+    }
+
+    let overrideProxy = session.getSessionData<boolean>("ipinfo.override_proxy", undefined);
+    if(overrideProxy !== undefined) {
+      ipInfo.proxy = overrideProxy;
+    }
+
     session.setSessionData("ipinfo.data", ipInfo);
 
     let sessionRestriction = this.getSessionRestriction(session);

--- a/src/modules/ipinfo/IPInfoModule.ts
+++ b/src/modules/ipinfo/IPInfoModule.ts
@@ -92,7 +92,10 @@ export class IPInfoModule extends BaseModule<IIPInfoConfig> {
     if(sessionRestriction.blocked) {
       let err = new FaucetError("IPINFO_RESTRICTION", "IP Blocked: " + sessionRestriction.messages.map((msg) => msg.text).join(", "));
       if(sessionRestriction.hostingBased || sessionRestriction.proxyBased) {
-        (err as any).data = [ sessionRestriction.hostingBased, sessionRestriction.proxyBased ];
+        err.data = { 
+          "address": session.getTargetAddr(),
+          "ipflags": [ sessionRestriction.hostingBased, sessionRestriction.proxyBased ],
+        };
       }
       throw err;
     }

--- a/src/modules/mainnet-wallet/MainnetWalletModule.ts
+++ b/src/modules/mainnet-wallet/MainnetWalletModule.ts
@@ -13,7 +13,7 @@ export class MainnetWalletModule extends BaseModule<IMainnetWalletConfig> {
 
   protected override startModule(): Promise<void> {
     this.startWeb3();
-    this.moduleManager.addActionHook(this, ModuleHookAction.SessionStart, 6, "Mainnet Wallet check", (session: FaucetSession, userInput: any) => this.processSessionStart(session, userInput));
+    this.moduleManager.addActionHook(this, ModuleHookAction.SessionStart, 7, "Mainnet Wallet check", (session: FaucetSession, userInput: any) => this.processSessionStart(session, userInput));
     return Promise.resolve();
   }
 

--- a/src/modules/passport/PassportConfig.ts
+++ b/src/modules/passport/PassportConfig.ts
@@ -9,6 +9,10 @@ export interface IPassportConfig extends IBaseModuleConfig {
   stampDeduplicationTime: number;
   stampScoring: {[stamp: string]: number};
   boostFactor: {[score: number]: number};
+  skipProxyCheckScore: number;
+  skipHostingCheckScore: number;
+  allowGuestRefresh: boolean;
+  guestRefreshCooldown: number;
 }
 
 export const defaultConfig: IPassportConfig = {
@@ -21,4 +25,8 @@ export const defaultConfig: IPassportConfig = {
   stampDeduplicationTime: 86400 * 3,
   stampScoring: {},
   boostFactor: {},
+  skipProxyCheckScore: 0,
+  skipHostingCheckScore: 0,
+  allowGuestRefresh: false,
+  guestRefreshCooldown: 0,
 }

--- a/src/modules/passport/PassportModule.ts
+++ b/src/modules/passport/PassportModule.ts
@@ -130,8 +130,7 @@ export class PassportModule extends BaseModule<IPassportConfig> {
 
       address = session.getTargetAddr();
       refreshCooldown = this.moduleConfig.refreshCooldown;
-    }
-    else if(!sessionId) {
+    } else {
       if (!this.moduleConfig.allowGuestRefresh) {
         return {
           code: "NOT_ALLOWED",
@@ -195,7 +194,7 @@ export class PassportModule extends BaseModule<IPassportConfig> {
     return {
       passport: passportInfo,
       score: passportScore,
-      cooldown: now + this.moduleConfig.refreshCooldown,
+      cooldown: now + refreshCooldown,
     };
   }
 

--- a/src/modules/passport/PassportModule.ts
+++ b/src/modules/passport/PassportModule.ts
@@ -29,6 +29,8 @@ export class PassportModule extends BaseModule<IPassportConfig> {
           manualVerification: (this.moduleConfig.trustedIssuers && this.moduleConfig.trustedIssuers.length > 0),
           stampScoring: this.moduleConfig.stampScoring,
           boostFactor: this.moduleConfig.boostFactor,
+          overrideScores: [ this.moduleConfig.skipHostingCheckScore, this.moduleConfig.skipProxyCheckScore ],
+          guestRefresh: this.moduleConfig.allowGuestRefresh ? (this.moduleConfig.guestRefreshCooldown > 0 ? this.moduleConfig.guestRefreshCooldown : this.moduleConfig.refreshCooldown) : false,
         };
       }
     );
@@ -75,7 +77,15 @@ export class PassportModule extends BaseModule<IPassportConfig> {
     let passportInfo = await this.passportResolver.getPassport(targetAddr);
     session.setSessionData("passport.refresh", Math.floor(new Date().getTime() / 1000));
     session.setSessionData("passport.data", passportInfo);
-    session.setSessionData("passport.score", this.passportResolver.getPassportScore(passportInfo));
+    let score = this.passportResolver.getPassportScore(passportInfo);
+    session.setSessionData("passport.score", score);
+
+    if(this.moduleConfig.skipHostingCheckScore > 0 && score.score >= this.moduleConfig.skipHostingCheckScore) {
+      session.setSessionData("ipinfo.override_hosting", false);
+    }
+    if(this.moduleConfig.skipProxyCheckScore > 0 && score.score >= this.moduleConfig.skipProxyCheckScore) {
+      session.setSessionData("ipinfo.override_proxy", false);
+    }
   }
 
   private async processSessionInfo(session: FaucetSession, moduleState: any): Promise<void> {
@@ -107,18 +117,44 @@ export class PassportModule extends BaseModule<IPassportConfig> {
   private async processPassportRefresh(req: IncomingMessage, url: IFaucetApiUrl, body: Buffer): Promise<any> {
     let sessionId = url.query['session'] as string;
     let session: FaucetSession;
-    if(!sessionId || !(session = ServiceManager.GetService(SessionManager).getSession(sessionId, [FaucetSessionStatus.RUNNING]))) {
-      return {
-        code: "INVALID_SESSION",
-        error: "Session not found"
-      };
+    let address: string;
+    let refreshCooldown: number;
+    
+    if(sessionId) {
+      if(!(session = ServiceManager.GetService(SessionManager).getSession(sessionId, [FaucetSessionStatus.RUNNING]))) {
+        return {
+          code: "INVALID_SESSION",
+          error: "Session not found"
+        };
+      }
+
+      address = session.getTargetAddr();
+      refreshCooldown = this.moduleConfig.refreshCooldown;
+    }
+    else if(!sessionId) {
+      if (!this.moduleConfig.allowGuestRefresh) {
+        return {
+          code: "NOT_ALLOWED",
+          error: "Passport refresh not allowed without active session"
+        };
+      }
+
+      address = url.query['address'] as string;
+      if (!address || !address.match(/^0x[0-9a-fA-F]{40}$/) || address.match(/^0x0{40}$/i)) {
+        return {
+          code: "INVALID_ADDRESS",
+          error: "Invalid address"
+        };
+      }
+
+      refreshCooldown = this.moduleConfig.guestRefreshCooldown > 0 ? this.moduleConfig.guestRefreshCooldown : this.moduleConfig.refreshCooldown;
     }
 
     let now = Math.floor(new Date().getTime() / 1000);
     let passportInfo: IPassportInfo;
     if(req.method === "POST") {
       // manual refresh
-      let verifyResult = await this.passportResolver.verifyUserPassport(session.getTargetAddr(), JSON.parse(body.toString("utf8")));
+      let verifyResult = await this.passportResolver.verifyUserPassport(address, JSON.parse(body.toString("utf8")));
       if(!verifyResult.valid) {
         return {
           code: "PASSPORT_VALIDATION",
@@ -130,22 +166,31 @@ export class PassportModule extends BaseModule<IPassportConfig> {
     }
     else {
       // auto refresh
-      let lastRefresh = session.getSessionData("passport.refresh") || 0;
-      if(now - lastRefresh < this.moduleConfig.refreshCooldown) {
+      let lastRefresh: number;
+      if(session) {
+        lastRefresh = session.getSessionData("passport.refresh") || 0;
+      } else {
+        let cachedPassport = await this.passportResolver.getCachedPassport(address);
+        lastRefresh = cachedPassport ? cachedPassport.parsed : 0;
+      }
+
+      if(now - lastRefresh < refreshCooldown) {
         return {
           code: "REFRESH_COOLDOWN",
-          error: "Passport has been refreshed recently. Please wait " + (lastRefresh + this.moduleConfig.refreshCooldown - now) + " sec",
-          cooldown: lastRefresh + this.moduleConfig.refreshCooldown,
+          error: "Passport has been refreshed recently. Please wait " + (lastRefresh + refreshCooldown - now) + " sec",
+          cooldown: lastRefresh + refreshCooldown,
         };
       }
 
-      passportInfo = await this.passportResolver.getPassport(session.getTargetAddr(), true);
+      passportInfo = await this.passportResolver.getPassport(address, true);
     }
 
     let passportScore = this.passportResolver.getPassportScore(passportInfo);
-    session.setSessionData("passport.refresh", now);
-    session.setSessionData("passport.data", passportInfo);
-    session.setSessionData("passport.score", passportScore);
+    if(session) {
+      session.setSessionData("passport.refresh", now);
+      session.setSessionData("passport.data", passportInfo);
+      session.setSessionData("passport.score", passportScore);
+    }
 
     return {
       passport: passportInfo,
@@ -156,20 +201,42 @@ export class PassportModule extends BaseModule<IPassportConfig> {
 
   private async processGetPassportInfo(req: IncomingMessage, url: IFaucetApiUrl, body: Buffer): Promise<any> {
     let sessionId = url.query['session'] as string;
-    let session: FaucetSession;
-    if(!sessionId || !(session = ServiceManager.GetService(SessionManager).getSession(sessionId, [FaucetSessionStatus.RUNNING]))) {
-      return {
-        code: "INVALID_SESSION",
-        error: "Session not found"
-      };
+    let passportInfo: IPassportInfo
+
+    if(sessionId) {
+      let session: FaucetSession;
+      if(!(session = ServiceManager.GetService(SessionManager).getSession(sessionId, [FaucetSessionStatus.RUNNING]))) {
+        return {
+          code: "INVALID_SESSION",
+          error: "Session not found"
+        };
+      }
+
+      passportInfo = session.getSessionData("passport.data");
+      if(!passportInfo) {
+        return {
+          code: "INVALID_PASSPORT",
+          error: "Passport not found"
+        };
+      }
     }
-    
-    let passportInfo: IPassportInfo = session.getSessionData("passport.data");
-    if(!passportInfo) {
-      return {
-        code: "INVALID_PASSPORT",
-        error: "Passport not found"
-      };
+    else if(!sessionId) {
+      if (!this.moduleConfig.allowGuestRefresh) {
+        return {
+          code: "NOT_ALLOWED",
+          error: "Passport info not allowed without active session"
+        };
+      }
+
+      let address = url.query['address'] as string;
+      if (!address || !address.match(/^0x[0-9a-fA-F]{40}$/) || address.match(/^0x0{40}$/i)) {
+        return {
+          code: "INVALID_ADDRESS",
+          error: "Invalid address"
+        };
+      }
+
+      passportInfo = await this.passportResolver.getCachedPassport(address);
     }
     
     return {

--- a/src/modules/passport/PassportResolver.ts
+++ b/src/modules/passport/PassportResolver.ts
@@ -85,6 +85,13 @@ export class PassportResolver {
     this.passportScoreNonce++;
   }
 
+  public getCachedPassport(addr: string): Promise<IPassportInfo> {
+    if(this.passportCache.hasOwnProperty(addr))
+      return this.passportCache[addr];
+
+    return this.module.getPassportDb().getPassportInfo(addr);
+  }
+
   public getPassport(addr: string, refresh?: boolean): Promise<IPassportInfo> {
     if(this.passportCache.hasOwnProperty(addr))
       return this.passportCache[addr];

--- a/src/modules/recurring-limits/RecurringLimitsModule.ts
+++ b/src/modules/recurring-limits/RecurringLimitsModule.ts
@@ -14,7 +14,7 @@ export class RecurringLimitsModule extends BaseModule<IRecurringLimitsConfig> {
 
   protected override startModule(): Promise<void> {
     this.moduleManager.addActionHook(
-      this, ModuleHookAction.SessionStart, 6, "Recurring limits check", 
+      this, ModuleHookAction.SessionStart, 7, "Recurring limits check", 
       (session: FaucetSession, userInput: any) => this.processSessionStart(session, userInput)
     );
     this.moduleManager.addActionHook(

--- a/src/webserv/FaucetWebApi.ts
+++ b/src/webserv/FaucetWebApi.ts
@@ -212,8 +212,8 @@ export class FaucetWebApi {
           failedCode: ex.getCode(),
           failedReason: ex.message,
         }
-        if(ex.hasOwnProperty("data")) {
-          data.data = (ex as any).data;
+        if(ex.data) {
+          data.failedData = (ex as any).data;
         }
 
         return data;

--- a/src/webserv/FaucetWebApi.ts
+++ b/src/webserv/FaucetWebApi.ts
@@ -207,11 +207,16 @@ export class FaucetWebApi {
       sessionInfo = await session.getSessionInfo();
     } catch(ex) {
       if(ex instanceof FaucetError) {
-        return {
+        let data: any = {
           status: FaucetSessionStatus.FAILED,
           failedCode: ex.getCode(),
           failedReason: ex.message,
         }
+        if(ex.hasOwnProperty("data")) {
+          data.data = (ex as any).data;
+        }
+
+        return data;
       }
       else {
         return {

--- a/tests/modules/PassportModule.spec.ts
+++ b/tests/modules/PassportModule.spec.ts
@@ -68,7 +68,7 @@ describe("Faucet module: passport", () => {
     expect(clientConfig.modules['passport'].manualVerification).to.equal(true, "client config missmatch: manualVerification");
     expect(JSON.stringify(clientConfig.modules['passport'].stampScoring)).to.equal(JSON.stringify((faucetConfig.modules["passport"] as any).stampScoring), "client config missmatch: stampScoring");
     expect(JSON.stringify(clientConfig.modules['passport'].overrideScores)).to.equal(JSON.stringify([10, 20]), "client config missmatch: overrideScores");
-    expect(JSON.stringify(clientConfig.modules['passport'].guestRefresh)).to.equal(60, "client config missmatch: guestRefresh");
+    expect(clientConfig.modules['passport'].guestRefresh).to.equal(60, "client config missmatch: guestRefresh");
   }).timeout(6000); // might take longer than the other passport tests, because the didkit lib is loaded when the module gets enabled first
 
   it("Start session with successful passport request", async () => {

--- a/tests/modules/PassportModule.spec.ts
+++ b/tests/modules/PassportModule.spec.ts
@@ -56,6 +56,10 @@ describe("Faucet module: passport", () => {
       boostFactor: {
         2: 4,
       },
+      skipHostingCheckScore: 10,
+      skipProxyCheckScore: 20,
+      allowGuestRefresh: true,
+      guestRefreshCooldown: 60,
     } as any;
     await ServiceManager.GetService(ModuleManager).initialize();
     let clientConfig = ServiceManager.GetService(FaucetWebApi).onGetFaucetConfig();
@@ -63,7 +67,8 @@ describe("Faucet module: passport", () => {
     expect(clientConfig.modules['passport'].refreshTimeout).to.equal(30, "client config missmatch: refreshTimeout");
     expect(clientConfig.modules['passport'].manualVerification).to.equal(true, "client config missmatch: manualVerification");
     expect(JSON.stringify(clientConfig.modules['passport'].stampScoring)).to.equal(JSON.stringify((faucetConfig.modules["passport"] as any).stampScoring), "client config missmatch: stampScoring");
-    expect(JSON.stringify(clientConfig.modules['passport'].boostFactor)).to.equal(JSON.stringify((faucetConfig.modules["passport"] as any).boostFactor), "client config missmatch: boostFactor");
+    expect(JSON.stringify(clientConfig.modules['passport'].overrideScores)).to.equal([10, 20], "client config missmatch: overrideScores");
+    expect(JSON.stringify(clientConfig.modules['passport'].guestRefresh)).to.equal(60, "client config missmatch: guestRefresh");
   }).timeout(6000); // might take longer than the other passport tests, because the didkit lib is loaded when the module gets enabled first
 
   it("Start session with successful passport request", async () => {

--- a/tests/modules/PassportModule.spec.ts
+++ b/tests/modules/PassportModule.spec.ts
@@ -67,7 +67,7 @@ describe("Faucet module: passport", () => {
     expect(clientConfig.modules['passport'].refreshTimeout).to.equal(30, "client config missmatch: refreshTimeout");
     expect(clientConfig.modules['passport'].manualVerification).to.equal(true, "client config missmatch: manualVerification");
     expect(JSON.stringify(clientConfig.modules['passport'].stampScoring)).to.equal(JSON.stringify((faucetConfig.modules["passport"] as any).stampScoring), "client config missmatch: stampScoring");
-    expect(JSON.stringify(clientConfig.modules['passport'].overrideScores)).to.equal([10, 20], "client config missmatch: overrideScores");
+    expect(JSON.stringify(clientConfig.modules['passport'].overrideScores)).to.equal(JSON.stringify([10, 20]), "client config missmatch: overrideScores");
     expect(JSON.stringify(clientConfig.modules['passport'].guestRefresh)).to.equal(60, "client config missmatch: guestRefresh");
   }).timeout(6000); // might take longer than the other passport tests, because the didkit lib is loaded when the module gets enabled first
 


### PR DESCRIPTION
This implements the ability to skip the IP based proxy/hosting check for wallets that meet a specific passport score.
