### PR TITLE
Support env var injection for faucet and module secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Read the [Faucet Operator Wiki](https://github.com/pk910/PoWFaucet/wiki/Operator
 
 You can also find some demo instances with different module combinations here: [Demo Instances](https://github.com/pk910/PoWFaucet/blob/master/docs/demo/README.md)
 
+Secrets can also be injected at runtime instead of being stored in `faucet-config.yaml`. The local examples document `FAUCET_SECRET`, `FAUCET_ETH_WALLET_KEY`, `FAUCET_CAPTCHA_SECRET`, `FAUCET_GITHUB_APP_SECRET`, and `FAUCET_PASSPORT_SCORER_API_KEY`.
+
 # Bugs & Features
 
 Please feel free to report bugs and add new features via PRs if you like.

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -5,6 +5,8 @@ All demo instances will drop a useless ERC20 token (["PoWC"](https://holesky.eth
 The demo instances are there to show different configuration scenarios with different modules enabled.\
 If your're looking for native testnet funds, use one of my [productive instances](https://github.com/pk910/PoWFaucet#instances).
 
+Sensitive values shown in the demo configs can also be injected at runtime. The local examples document `FAUCET_SECRET`, `FAUCET_ETH_WALLET_KEY`, `FAUCET_CAPTCHA_SECRET`, `FAUCET_GITHUB_APP_SECRET`, and `FAUCET_PASSPORT_SCORER_API_KEY`.
+
 ### Demo 1
 
 Low protection configuration, mainly based on captchas only.\
@@ -130,4 +132,3 @@ Modules:
 To be clear: The examples above are just examples to demonstrate different scenarios with different protection methods.\
 All faucet modules can be used independently, so you can configure the faucet for your protection needs. \
 For best protection, I recommend using a combination of several modules. I recommend to use the `recurring-limits`, `ethinfo` & `captcha` modules as a "minimum protection".
-

--- a/docs/demo/demo1-config.yaml
+++ b/docs/demo/demo1-config.yaml
@@ -48,6 +48,7 @@ faucetHomeHtml: |
 
 # random secret string that is used by the faucet to "sign" session data, so sessions can be restored automatically by clients when faucet is restarted / crashed
 # use a random string and do not share / reuse it anywhere. Everyone knowing this secret is theoretically able to claim rewards from the faucet without mining.
+# can be overridden at runtime with FAUCET_SECRET
 faucetSecret: "***censored***"
 
 # ETH execution layer RPC host
@@ -55,6 +56,7 @@ ethRpcHost: "https://holesky.infura.io/v3/***censored***"
 #ethRpcHost: "https://rpc.holesky.ethpandaops.io"
 
 # faucet wallet private key (hex, without 0x prefix)
+# can be overridden at runtime with FAUCET_ETH_WALLET_KEY
 ethWalletKey: "***censored***"
 
 # EVM chain id (null for auto-detect from RPC)
@@ -127,6 +129,7 @@ modules:
     siteKey: "a62dab4f-e790-42ab-acbf-47f1c029870a"
 
     # captcha secret key
+    # can be overridden at runtime with FAUCET_CAPTCHA_SECRET
     secret: "0x***censored***"
 
     # require captcha to start a new session (default: false)

--- a/docs/demo/demo2-config.yaml
+++ b/docs/demo/demo2-config.yaml
@@ -44,6 +44,7 @@ faucetHomeHtml: |
 
 # random secret string that is used by the faucet to "sign" session data, so sessions can be restored automatically by clients when faucet is restarted / crashed
 # use a random string and do not share / reuse it anywhere. Everyone knowing this secret is theoretically able to claim rewards from the faucet without mining.
+# can be overridden at runtime with FAUCET_SECRET
 faucetSecret: "***censored***"
 
 # ETH execution layer RPC host
@@ -51,6 +52,7 @@ ethRpcHost: "https://holesky.infura.io/v3/***censored***"
 #ethRpcHost: "https://rpc.holesky.ethpandaops.io"
 
 # faucet wallet private key (hex, without 0x prefix)
+# can be overridden at runtime with FAUCET_ETH_WALLET_KEY
 ethWalletKey: "***censored***"
 
 # EVM chain id (null for auto-detect from RPC)
@@ -123,6 +125,7 @@ modules:
     siteKey: "a62dab4f-e790-42ab-acbf-47f1c029870a"
 
     # captcha secret key
+    # can be overridden at runtime with FAUCET_CAPTCHA_SECRET
     secret: "0x***censored***"
 
     # require captcha to start a new session (default: false)

--- a/docs/demo/demo3-config.yaml
+++ b/docs/demo/demo3-config.yaml
@@ -47,6 +47,7 @@ faucetHomeHtml: |
 
 # random secret string that is used by the faucet to "sign" session data, so sessions can be restored automatically by clients when faucet is restarted / crashed
 # use a random string and do not share / reuse it anywhere. Everyone knowing this secret is theoretically able to claim rewards from the faucet without mining.
+# can be overridden at runtime with FAUCET_SECRET
 faucetSecret: "***censored***"
 
 # ETH execution layer RPC host
@@ -54,6 +55,7 @@ ethRpcHost: "https://holesky.infura.io/v3/***censored***"
 #ethRpcHost: "https://rpc.holesky.ethpandaops.io"
 
 # faucet wallet private key (hex, without 0x prefix)
+# can be overridden at runtime with FAUCET_ETH_WALLET_KEY
 ethWalletKey: "***censored***"
 
 # EVM chain id (null for auto-detect from RPC)

--- a/docs/demo/demo4-config.yaml
+++ b/docs/demo/demo4-config.yaml
@@ -47,6 +47,7 @@ faucetHomeHtml: |
 
 # random secret string that is used by the faucet to "sign" session data, so sessions can be restored automatically by clients when faucet is restarted / crashed
 # use a random string and do not share / reuse it anywhere. Everyone knowing this secret is theoretically able to claim rewards from the faucet without mining.
+# can be overridden at runtime with FAUCET_SECRET
 faucetSecret: "***censored***"
 
 # ETH execution layer RPC host
@@ -54,6 +55,7 @@ ethRpcHost: "https://holesky.infura.io/v3/***censored***"
 #ethRpcHost: "https://rpc.holesky.ethpandaops.io"
 
 # faucet wallet private key (hex, without 0x prefix)
+# can be overridden at runtime with FAUCET_ETH_WALLET_KEY
 ethWalletKey: "***censored***"
 
 # EVM chain id (null for auto-detect from RPC)
@@ -161,6 +163,7 @@ modules:
   ## Passport protection
   passport:
     enabled: true
+    # can be overridden at runtime with FAUCET_PASSPORT_SCORER_API_KEY
     scorerApiKey: "***censored***" # Gitcoin Passport Scorer API Key
     trustedIssuers:
       - "did:key:z6MkghvGHLobLEdj1bgRLhS4LPGJAvbMA1tn2zcRyqmYU5LC" # Gitcoin Passport
@@ -311,4 +314,3 @@ resultSharing:
   #  <div class="sh-opt">
   #  </div>
   caption: ""
-

--- a/docs/demo/demo5-config.yaml
+++ b/docs/demo/demo5-config.yaml
@@ -49,6 +49,7 @@ faucetHomeHtml: |
 
 # random secret string that is used by the faucet to "sign" session data, so sessions can be restored automatically by clients when faucet is restarted / crashed
 # use a random string and do not share / reuse it anywhere. Everyone knowing this secret is theoretically able to claim rewards from the faucet without mining.
+# can be overridden at runtime with FAUCET_SECRET
 faucetSecret: "***censored***"
 
 # ETH execution layer RPC host
@@ -56,6 +57,7 @@ ethRpcHost: "https://holesky.infura.io/v3/***censored***"
 #ethRpcHost: "https://rpc.holesky.ethpandaops.io"
 
 # faucet wallet private key (hex, without 0x prefix)
+# can be overridden at runtime with FAUCET_ETH_WALLET_KEY
 ethWalletKey: "***censored***"
 
 # EVM chain id (null for auto-detect from RPC)
@@ -128,6 +130,7 @@ modules:
     siteKey: "a62dab4f-e790-42ab-acbf-47f1c029870a"
 
     # captcha secret key
+    # can be overridden at runtime with FAUCET_CAPTCHA_SECRET
     secret: "0x***censored***"
 
     # require captcha to start a new session (default: false)
@@ -155,6 +158,7 @@ modules:
 
     # github api credentials
     appClientId: "056812ab38f99f509f08"
+    # can be overridden at runtime with FAUCET_GITHUB_APP_SECRET
     appSecret: "***censored***"
 
     # authentication timeout

--- a/faucet-config.example.yaml
+++ b/faucet-config.example.yaml
@@ -49,6 +49,7 @@ faucetHomeHtml: |
 
 # random secret string that is used by the faucet to "sign" session data, so sessions can be restored automatically by clients when faucet is restarted / crashed
 # use a random string and do not share / reuse it anywhere. Everyone knowing this secret is theoretically able to claim rewards from the faucet without mining.
+# can be overridden at runtime with FAUCET_SECRET
 faucetSecret: "RandomStringThatShouldBeVerySecret!"
 
 # ETH execution layer RPC host
@@ -56,6 +57,7 @@ faucetSecret: "RandomStringThatShouldBeVerySecret!"
 ethRpcHost: "https://rpc.hoodi.ethpandaops.io"
 
 # faucet wallet private key (hex, without 0x prefix)
+# can be overridden at runtime with FAUCET_ETH_WALLET_KEY
 ethWalletKey: "feedbeef12340000feedbeef12340000feedbeef12340000feedbeef12340000"
 
 # EVM chain id (null for auto-detect from RPC)
@@ -132,6 +134,7 @@ modules:
     siteKey: "00000000-0000-0000-0000-000000000000"
 
     # captcha secret key
+    # can be overridden at runtime with FAUCET_CAPTCHA_SECRET
     secret: "0xCensoredHCaptchaSecretKey"
 
     # require captcha to start a new session (default: false)
@@ -239,6 +242,7 @@ modules:
 
     # github api credentials
     appClientId: "" # client id from github app
+    # can be overridden at runtime with FAUCET_GITHUB_APP_SECRET
     appSecret: "" # app secret from github app
 
     # authentication timeout
@@ -353,6 +357,7 @@ modules:
   ## Passport protection
   passport:
     enabled: false
+    # can be overridden at runtime with FAUCET_PASSPORT_SCORER_API_KEY
     scorerApiKey: "" # Gitcoin Passport Scorer API Key
     trustedIssuers:
       - "did:key:z6MkghvGHLobLEdj1bgRLhS4LPGJAvbMA1tn2zcRyqmYU5LC" # Gitcoin Passport

--- a/src/config/FaucetConfig.ts
+++ b/src/config/FaucetConfig.ts
@@ -7,6 +7,9 @@ import { ServiceManager } from '../common/ServiceManager.js';
 import { FaucetLogLevel, FaucetProcess } from '../common/FaucetProcess.js';
 import { IConfigSchema } from './ConfigSchema.js';
 import { getDefaultConfig } from './DefaultConfig.js';
+import { ICaptchaConfig } from '../modules/captcha/CaptchaConfig.js';
+import { IGithubConfig } from '../modules/github/GithubConfig.js';
+import { IPassportConfig } from '../modules/passport/PassportConfig.js';
 
 export let cliArgs = (function() {
   let args = {};
@@ -117,6 +120,27 @@ export function loadFaucetConfig(loadDefaultsOnly?: boolean) {
   } as any);
 
   // Apply environment variable overrides (used by Docker image with internal nginx)
+  if(process.env.FAUCET_SECRET) {
+    faucetConfig.faucetSecret = process.env.FAUCET_SECRET;
+  }
+  if(process.env.FAUCET_ETH_WALLET_KEY) {
+    faucetConfig.ethWalletKey = process.env.FAUCET_ETH_WALLET_KEY;
+  }
+  if(process.env.FAUCET_CAPTCHA_SECRET) {
+    if(!faucetConfig.modules.captcha)
+      faucetConfig.modules.captcha = {} as ICaptchaConfig;
+    (faucetConfig.modules.captcha as ICaptchaConfig).secret = process.env.FAUCET_CAPTCHA_SECRET;
+  }
+  if(process.env.FAUCET_GITHUB_APP_SECRET) {
+    if(!faucetConfig.modules.github)
+      faucetConfig.modules.github = {} as IGithubConfig;
+    (faucetConfig.modules.github as IGithubConfig).appSecret = process.env.FAUCET_GITHUB_APP_SECRET;
+  }
+  if(process.env.FAUCET_PASSPORT_SCORER_API_KEY) {
+    if(!faucetConfig.modules.passport)
+      faucetConfig.modules.passport = {} as IPassportConfig;
+    (faucetConfig.modules.passport as IPassportConfig).scorerApiKey = process.env.FAUCET_PASSPORT_SCORER_API_KEY;
+  }
   if(process.env.FAUCET_SERVER_PORT) {
     faucetConfig.serverPort = parseInt(process.env.FAUCET_SERVER_PORT, 10);
   }

--- a/tests/FaucetProcess.spec.ts
+++ b/tests/FaucetProcess.spec.ts
@@ -11,6 +11,9 @@ import { FaucetLogLevel, FaucetProcess } from '../src/common/FaucetProcess.js';
 import { sleepPromise } from '../src/utils/PromiseUtils.js';
 import { cliArgs, faucetConfig, getAppDataDir, loadFaucetConfig, setAppBasePath } from '../src/config/FaucetConfig.js';
 import { FaucetWorkers } from '../src/common/FaucetWorker.js';
+import { ICaptchaConfig } from '../src/modules/captcha/CaptchaConfig.js';
+import { IGithubConfig } from '../src/modules/github/GithubConfig.js';
+import { IPassportConfig } from '../src/modules/passport/PassportConfig.js';
 
 
 describe("Faucet Process", () => {
@@ -202,6 +205,11 @@ describe("Faucet Process", () => {
   it("Check config validation", async () => {
     let oldConfigArg = cliArgs["config"];
     let oldDatadir = cliArgs["datadir"];
+    let oldFaucetSecret = process.env.FAUCET_SECRET;
+    let oldWalletKey = process.env.FAUCET_ETH_WALLET_KEY;
+    let oldCaptchaSecret = process.env.FAUCET_CAPTCHA_SECRET;
+    let oldGithubAppSecret = process.env.FAUCET_GITHUB_APP_SECRET;
+    let oldPassportScorerApiKey = process.env.FAUCET_PASSPORT_SCORER_API_KEY;
 
     let tempdir = tmpFile("powfaucet-", "-data");
     fs.mkdirSync(tempdir);
@@ -219,10 +227,56 @@ describe("Faucet Process", () => {
     expect(error).to.contain("V1 configuration is incompatible", "no error for v1 config");
 
     // check autofilled values
-    fs.writeFileSync(path.join(tempdir, "good-config.yaml"), "version: 2");
+    fs.writeFileSync(path.join(tempdir, "good-config.yaml"), [
+      "version: 2",
+      "modules:",
+      "  captcha:",
+      "    secret: yaml-captcha-secret",
+      "  github:",
+      "    appSecret: yaml-github-secret",
+      "  passport:",
+      "    scorerApiKey: yaml-passport-api-key",
+    ].join("\n"));
     cliArgs["config"] = "good-config.yaml"
     loadFaucetConfig();
     expect(faucetConfig.faucetSecret.length).to.be.above(10, "no random faucetSecret generated");
+
+    process.env.FAUCET_SECRET = "env-faucet-secret";
+    process.env.FAUCET_ETH_WALLET_KEY = "feedbeef12340000feedbeef12340000feedbeef12340000feedbeef12340000";
+    process.env.FAUCET_CAPTCHA_SECRET = "env-captcha-secret";
+    process.env.FAUCET_GITHUB_APP_SECRET = "env-github-secret";
+    process.env.FAUCET_PASSPORT_SCORER_API_KEY = "env-passport-api-key";
+    loadFaucetConfig();
+    expect(faucetConfig.faucetSecret).to.equal(process.env.FAUCET_SECRET, "env override for faucetSecret not applied");
+    expect(faucetConfig.ethWalletKey).to.equal(process.env.FAUCET_ETH_WALLET_KEY, "env override for ethWalletKey not applied");
+    expect((faucetConfig.modules.captcha as ICaptchaConfig).secret).to.equal(process.env.FAUCET_CAPTCHA_SECRET, "env override for captcha secret not applied");
+    expect((faucetConfig.modules.github as IGithubConfig).appSecret).to.equal(process.env.FAUCET_GITHUB_APP_SECRET, "env override for github app secret not applied");
+    expect((faucetConfig.modules.passport as IPassportConfig).scorerApiKey).to.equal(process.env.FAUCET_PASSPORT_SCORER_API_KEY, "env override for passport scorer api key not applied");
+
+    if(typeof oldFaucetSecret === "string")
+      process.env.FAUCET_SECRET = oldFaucetSecret;
+    else
+      delete process.env.FAUCET_SECRET;
+
+    if(typeof oldWalletKey === "string")
+      process.env.FAUCET_ETH_WALLET_KEY = oldWalletKey;
+    else
+      delete process.env.FAUCET_ETH_WALLET_KEY;
+
+    if(typeof oldCaptchaSecret === "string")
+      process.env.FAUCET_CAPTCHA_SECRET = oldCaptchaSecret;
+    else
+      delete process.env.FAUCET_CAPTCHA_SECRET;
+
+    if(typeof oldGithubAppSecret === "string")
+      process.env.FAUCET_GITHUB_APP_SECRET = oldGithubAppSecret;
+    else
+      delete process.env.FAUCET_GITHUB_APP_SECRET;
+
+    if(typeof oldPassportScorerApiKey === "string")
+      process.env.FAUCET_PASSPORT_SCORER_API_KEY = oldPassportScorerApiKey;
+    else
+      delete process.env.FAUCET_PASSPORT_SCORER_API_KEY;
 
     cliArgs["config"] = oldConfigArg;
     cliArgs["datadir"] = oldDatadir;


### PR DESCRIPTION
## Summary

This PR adds runtime environment-variable overrides for secret-bearing config values so operators do not need to store them directly in `faucet-config.yaml` or demo config files.

Supported overrides:

- `FAUCET_SECRET`
- `FAUCET_ETH_WALLET_KEY`
- `FAUCET_CAPTCHA_SECRET`
- `FAUCET_GITHUB_APP_SECRET`
- `FAUCET_PASSPORT_SCORER_API_KEY`

## Changes

- Add env-var overrides in config loading for:
  - faucet session secret
  - faucet wallet private key
  - captcha provider secret
  - GitHub app secret
  - Gitcoin Passport scorer API key
- Keep YAML config as the default source when env vars are not set
- Add config-loader test coverage for the new overrides
- Update `faucet-config.example.yaml` to document env-var availability
- Update demo config examples under `docs/demo/` to document which values can be injected at runtime
- Update `README.md` and `docs/demo/README.md` to mention runtime secret injection

## Motivation

The faucet already supports a limited set of runtime env-based overrides. Extending that pattern to secrets makes deployment safer and easier for Docker, CI/CD, and secret-manager based setups, while preserving backward compatibility for existing YAML-based deployments.

## Behavior

- Existing configs continue to work unchanged
- Environment variables take precedence over YAML values when set
- Operators can keep secret material out of committed config files
