### PR TITLE
eth: fall back to latest when EL rejects pending state tag

### DIFF
--- a/src/eth/EthWalletManager.ts
+++ b/src/eth/EthWalletManager.ts
@@ -175,7 +175,7 @@ export class EthWalletManager {
       chainIdPromise,
       tokenBalancePromise,
     ]).catch((ex) => {
-      if(ex.toString().match(/"pending" is not yet supported/)) {
+      if(ex.toString().match(/"pending" is not yet supported|pending state is not available|pending block is not available/i)) {
         return Promise.all([
           this.web3.eth.getBalance(this.walletAddr),
           this.web3.eth.getTransactionCount(this.walletAddr),


### PR DESCRIPTION
## Summary

Widen the regex that triggers the latest-tag fallback in `EthWalletManager.loadWalletState` so the faucet also recovers when Geth returns `"pending state is not available"` (or `"pending block is not available"`) instead of Reth's `"'pending' is not yet supported"`.

## Why

We're running this faucet against an Ethereum devnet whose primary RPC is Geth unstable (v1.17.3 on a post-Osaka/BAL fork). Geth responds to `eth_getBalance(wallet, "pending")` with:

```
{"error":{"code":-32000,"message":"pending state is not available"}}
```

The existing catch block in `src/eth/EthWalletManager.ts` only matches the string `"pending" is not yet supported`, so on Geth the error is rethrown instead of retried with the default (latest) tag, and the faucet logs `Error loading wallet state` every 12 s and never becomes ready.

Geth has emitted `"pending state is not available"` since **v1.12.1** (introduced in ethereum/go-ethereum#27218, merged 2023-05-31) whenever its on-demand pending block builder returns nil (while syncing, or when `generateWork` fails — which currently happens on bleeding-edge devnet forks).

Post-merge, Geth also builds the pending block empty (ethereum/go-ethereum#28440), so from a wallet-state polling standpoint `pending` and `latest` carry the same balance/nonce information. Falling back to `latest` is safe and equivalent — that's exactly what the existing code path already does for Reth.

## Change

```diff
- if(ex.toString().match(/"pending" is not yet supported/)) {
+ if(ex.toString().match(/"pending" is not yet supported|pending state is not available|pending block is not available/i)) {
```

One-line widening, case-insensitive, covers Reth + Geth + any future EL that phrases it similarly.

## Test plan

- [x] Confirmed against a live Geth `v1.17.3-unstable` RPC that `eth_getBalance(addr, "pending")` returns `-32000 "pending state is not available"` while `latest` works.
- [x] Confirmed against Nethermind / Besu / Reth / Erigon / Ethrex on the same devnet that `pending` succeeds and returns the same value as `latest` (i.e. the fallback path produces identical wallet state).
- [ ] Deploy the patched image on bal-devnet-3 and verify `loadWalletState` no longer errors when pointed at the Geth bootnode.