### PR TITLE
add authenticatoor auth module for ethpandaops infrastructure deployments

### DIFF
--- a/faucet-client/src/common/AuthenticatoorFragment.ts
+++ b/faucet-client/src/common/AuthenticatoorFragment.ts
@@ -1,0 +1,78 @@
+// Pre-mount handler for authenticatoor's /auth/login redirect.
+//
+// authenticatoor returns the user to <our origin>#auth_token=…&exp=…&user=…
+// after a successful login. The faucet uses HashRouter, so any unhandled
+// hash content is interpreted as a route — leaving the user with a blank
+// page until they reload from a clean URL.
+//
+// This module:
+//   1. Detects the auth_token fragment params on initial page load.
+//   2. Stashes them to sessionStorage with the exact keys authenticatoor's
+//      drop-in client.js library uses, so AuthenticatoorLogin's later
+//      checkLogin() picks the token up from cache.
+//   3. Strips just those params from the hash via history.replaceState,
+//      preserving any other fragment content (so it doesn't break the
+//      router on first paint).
+//
+// Mirrors `captureFromFragment()` in service-authenticatoor's client.js,
+// minus the network bits — this runs before our React tree mounts and
+// before that script even loads.
+
+const STORAGE_TOKEN = "ethpandaops.authenticatoor.token";
+const STORAGE_EXP = "ethpandaops.authenticatoor.exp";
+const STORAGE_USER = "ethpandaops.authenticatoor.user";
+
+function base64UrlDecode(s: string): string {
+  s = s.replace(/-/g, "+").replace(/_/g, "/");
+  while(s.length % 4) s += "=";
+  try { return atob(s); } catch(e) { return ""; }
+}
+
+function extractUserFromToken(token: string): string {
+  if(!token) return "";
+  let parts = token.split(".");
+  if(parts.length !== 3) return "";
+  let json = base64UrlDecode(parts[1]);
+  if(!json) return "";
+  try {
+    let c = JSON.parse(json);
+    return (c.email as string) || (c.sub as string) || "";
+  } catch(e) {
+    return "";
+  }
+}
+
+export function captureAuthenticatoorFragment(): void {
+  if(!window.location.hash || window.location.hash.length < 2)
+    return;
+
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(window.location.hash.slice(1));
+  } catch(e) {
+    return;
+  }
+
+  let token = params.get("auth_token");
+  let expStr = params.get("exp");
+  if(!token || !expStr)
+    return;
+  let exp = parseInt(expStr, 10);
+  if(!exp || isNaN(exp))
+    return;
+
+  let user = params.get("user") || extractUserFromToken(token);
+  try {
+    sessionStorage.setItem(STORAGE_TOKEN, token);
+    sessionStorage.setItem(STORAGE_EXP, String(exp));
+    sessionStorage.setItem(STORAGE_USER, user || "");
+  } catch(e) { /* private mode etc — fall through */ }
+
+  params.delete("auth_token");
+  params.delete("exp");
+  params.delete("user");
+  let remaining = params.toString();
+  let newURL = window.location.pathname + window.location.search +
+    (remaining ? "#" + remaining : "");
+  try { history.replaceState(null, "", newURL); } catch(e) {}
+}

--- a/faucet-client/src/common/FaucetConfig.ts
+++ b/faucet-client/src/common/FaucetConfig.ts
@@ -21,6 +21,7 @@ export interface IFaucetConfig {
     [provider: string]: string;
   };
   modules: {
+    authenticatoor?: IAuthenticatoorModuleConfig;
     captcha?: ICaptchaModuleConfig;
     ensname?: IEnsNameModuleConfig;
     github?: IGithubModuleConfig;
@@ -29,6 +30,15 @@ export interface IFaucetConfig {
     voucher?: IVoucherModuleConfig;
     zupass?: IZupassModuleConfig;
   };
+}
+
+export interface IAuthenticatoorModuleConfig {
+  authUrl: string;
+  requireLogin: boolean;
+  loginLabel: string | null;
+  userLabel: string | null;
+  infoHtml: string | null;
+  loginLogo: string | null;
 }
 
 export interface ICaptchaModuleConfig {

--- a/faucet-client/src/components/frontpage/FaucetInput.tsx
+++ b/faucet-client/src/components/frontpage/FaucetInput.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { IFaucetConfig } from '../../common/FaucetConfig';
 import { IFaucetContext } from '../../common/FaucetContext';
 import { FaucetCaptcha } from '../shared/FaucetCaptcha';
+import { AuthenticatoorLogin } from './authenticatoor/AuthenticatoorLogin';
 import { GithubLogin } from './github/GithubLogin';
 import { ZupassLogin } from './zupass/ZupassLogin';
 import VoucherInput, { IVoucherInputRef } from './voucher/VoucherInput';
@@ -20,6 +21,7 @@ export interface IFaucetInputState {
 
 export class FaucetInput extends React.PureComponent<IFaucetInputProps, IFaucetInputState> {
   private faucetCaptcha = React.createRef<FaucetCaptcha>();
+  private authenticatoorLogin = React.createRef<AuthenticatoorLogin>();
   private githubLogin = React.createRef<GithubLogin>();
   private zupassLogin = React.createRef<ZupassLogin>();
   private voucherInput = React.createRef<IVoucherInputRef>();
@@ -34,6 +36,7 @@ export class FaucetInput extends React.PureComponent<IFaucetInputProps, IFaucetI
   }
 
 	public render(): React.ReactElement<IFaucetInputProps> {
+    let needAuthenticatoor = !!this.props.faucetConfig.modules.authenticatoor;
     let needGithubAuth = !!this.props.faucetConfig.modules.github;
     let needZupassAuth = !!this.props.faucetConfig.modules.zupass && !!this.props.faucetConfig.modules.zupass.event;
     let needVoucher = !!this.props.faucetConfig.modules.voucher;
@@ -64,10 +67,17 @@ export class FaucetInput extends React.PureComponent<IFaucetInputProps, IFaucetI
           placeholder={"Please enter " + (inputTypes.join(" or "))} 
           onChange={(evt) => this.setState({ targetAddr: evt.target.value })} 
         />
-        {needGithubAuth ? 
-          <GithubLogin 
-            faucetConfig={this.props.faucetConfig} 
-            faucetContext={this.props.faucetContext} 
+        {needAuthenticatoor ?
+          <AuthenticatoorLogin
+            faucetConfig={this.props.faucetConfig}
+            faucetContext={this.props.faucetContext}
+            ref={this.authenticatoorLogin}
+          />
+        : null}
+        {needGithubAuth ?
+          <GithubLogin
+            faucetConfig={this.props.faucetConfig}
+            faucetContext={this.props.faucetContext}
             ref={this.githubLogin}
           />
         : null}
@@ -124,6 +134,9 @@ export class FaucetInput extends React.PureComponent<IFaucetInputProps, IFaucetI
       inputData.addr = this.state.targetAddr;
       if(this.props.faucetConfig.modules.captcha?.requiredForStart) {
         inputData.captchaToken = await this.faucetCaptcha.current?.getToken();
+      }
+      if(this.props.faucetConfig.modules.authenticatoor) {
+        inputData.authToken = this.authenticatoorLogin.current?.getToken() || undefined;
       }
       if(this.props.faucetConfig.modules.github) {
         inputData.githubToken = await this.githubLogin.current?.getToken();

--- a/faucet-client/src/components/frontpage/authenticatoor/AuthenticatoorLogin.css
+++ b/faucet-client/src/components/frontpage/authenticatoor/AuthenticatoorLogin.css
@@ -1,0 +1,44 @@
+.faucet-page .logo.logo-authenticatoor {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23343a40'%3E%3Cpath d='M8 1a3.5 3.5 0 0 0-3.5 3.5V7H4a2 2 0 0 0-2 2v5a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-.5V4.5A3.5 3.5 0 0 0 8 1Zm2.5 6V4.5a2.5 2.5 0 0 0-5 0V7h5Z'/%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
+  width: 100%;
+  height: 100%;
+}
+
+.faucet-page .faucet-authenticatoor-auth {
+  margin: 16px 0;
+  display: flex;
+}
+
+.faucet-page .faucet-authenticatoor-auth .auth-icon {
+  height: 50px;
+  width: 50px;
+  padding: 4px;
+}
+
+.faucet-page .faucet-authenticatoor-auth .auth-field {
+  margin: 0 16px;
+  flex-grow: 1;
+}
+
+.faucet-page .faucet-authenticatoor-auth .auth-field .auth-info {
+  color: #343a40;
+}
+
+.faucet-page .faucet-authenticatoor-auth .auth-info-icon {
+  margin-left: 8px;
+}
+
+.faucet-page .faucet-authenticatoor-auth .auth-logout {
+  float: right;
+}
+
+#authenticatoor-tooltip .tooltip-inner {
+  max-width: 500px;
+}
+
+#authenticatoor-tooltip .authenticatoor-info {
+  text-align: left;
+}

--- a/faucet-client/src/components/frontpage/authenticatoor/AuthenticatoorLogin.tsx
+++ b/faucet-client/src/components/frontpage/authenticatoor/AuthenticatoorLogin.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { OverlayChildren } from 'react-bootstrap/esm/Overlay';
+import { IFaucetConfig } from '../../../common/FaucetConfig';
+import { IFaucetContext } from '../../../common/FaucetContext';
+
+import './AuthenticatoorLogin.css';
+
+interface IAuthenticatoorTokenInfo {
+  authenticated: boolean;
+  token: string;
+  exp: number;
+  user: string;
+}
+
+interface IAuthenticatoorClient {
+  checkLogin(): Promise<IAuthenticatoorTokenInfo>;
+  login(): void;
+  logout(): void;
+  getToken(): string | null;
+  isLoggedIn(): boolean;
+  authServiceURL(): string;
+}
+
+declare global {
+  interface Window {
+    ethpandaops?: {
+      authenticatoor?: IAuthenticatoorClient;
+    };
+  }
+}
+
+export interface IAuthenticatoorLoginProps {
+  faucetContext: IFaucetContext;
+  faucetConfig: IFaucetConfig;
+}
+
+export interface IAuthenticatoorLoginState {
+  scriptLoading: boolean;
+  scriptLoaded: boolean;
+  scriptError: string | null;
+  loginInfo: IAuthenticatoorTokenInfo | null;
+}
+
+const SCRIPT_LOADERS: { [url: string]: Promise<void> } = {};
+
+function loadScript(src: string): Promise<void> {
+  if(SCRIPT_LOADERS[src])
+    return SCRIPT_LOADERS[src];
+  return SCRIPT_LOADERS[src] = new Promise<void>((resolve, reject) => {
+    let script = document.createElement("script");
+    script.src = src;
+    script.async = true;
+    script.onload = () => resolve();
+    script.onerror = () => {
+      delete SCRIPT_LOADERS[src];
+      reject(new Error("failed loading " + src));
+    };
+    document.head.appendChild(script);
+  });
+}
+
+export class AuthenticatoorLogin extends React.PureComponent<IAuthenticatoorLoginProps, IAuthenticatoorLoginState> {
+
+  constructor(props: IAuthenticatoorLoginProps) {
+    super(props);
+
+    this.state = {
+      scriptLoading: false,
+      scriptLoaded: false,
+      scriptError: null,
+      loginInfo: null,
+    };
+  }
+
+  public componentDidMount() {
+    let authUrl = this.props.faucetConfig.modules.authenticatoor?.authUrl;
+    if(!authUrl)
+      return;
+
+    let scriptUrl = authUrl.replace(/\/+$/, "") + "/client.js";
+    this.setState({ scriptLoading: true });
+
+    loadScript(scriptUrl).then(() => {
+      this.setState({ scriptLoading: false, scriptLoaded: true });
+      let client = window.ethpandaops?.authenticatoor;
+      if(!client) {
+        this.setState({ scriptError: "authenticatoor client did not initialize" });
+        return;
+      }
+      client.checkLogin().then((info) => {
+        this.setState({ loginInfo: info });
+      });
+    }).catch((err) => {
+      this.setState({
+        scriptLoading: false,
+        scriptError: err.message || err.toString(),
+      });
+    });
+  }
+
+  public render(): React.ReactElement {
+    return (
+      <div className='faucet-auth faucet-authenticatoor-auth'>
+        <div className='auth-icon'>
+          {this.props.faucetConfig.modules.authenticatoor.loginLogo ?
+            <div className='logo logo-authenticatoor' style={{backgroundImage: "url('"+ this.props.faucetConfig.modules.authenticatoor.loginLogo +"')"}}></div>
+          :
+            <div className='logo logo-authenticatoor'></div>
+          }
+        </div>
+        {this.state.loginInfo?.authenticated ?
+          this.renderAuthed() :
+          this.renderLogin()
+        }
+      </div>
+    );
+  }
+
+  private renderLogin(): React.ReactElement {
+    let modCfg = this.props.faucetConfig.modules.authenticatoor;
+    return (
+      <div className='auth-field auth-noauth'>
+        <div>
+          {modCfg.loginLabel || (modCfg.requireLogin ? "Login required to use this faucet." : "Optional login for additional benefits.")}
+          {modCfg.infoHtml ? this.renderInfoIcon() : null}
+        </div>
+        <div>
+          <a href="#" onClick={(evt) => { evt.preventDefault(); this.onLoginClick() }}>
+            {(this.state.scriptLoading || (this.state.scriptLoaded && !this.state.loginInfo && !this.state.scriptError)) ?
+              <span className='inline-spinner'>
+                <img src={(this.props.faucetContext.faucetUrls.imagesUrl || "/images") + "/spinner.gif"} className="spinner" />
+              </span>
+            : null}
+            Login
+          </a>
+        </div>
+        {this.state.scriptError ?
+          <div className='auth-info' style={{color: "#a00"}}>Failed to load auth client: {this.state.scriptError}</div>
+        : null}
+      </div>
+    );
+  }
+
+  private renderAuthed(): React.ReactElement {
+    let modCfg = this.props.faucetConfig.modules.authenticatoor;
+    let info = this.state.loginInfo;
+    return (
+      <div className='auth-field auth-profile'>
+        <div className='auth-info'>
+          {modCfg.userLabel || "Authenticated"}: <strong>{info.user || "(unknown)"}</strong>
+          {modCfg.infoHtml ? this.renderInfoIcon() : null}
+        </div>
+        <div className='auth-logout'>
+          <a href="#" onClick={(evt) => { evt.preventDefault(); this.onLogoutClick() }}>
+            Logout
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  private renderInfoIcon(): React.ReactElement {
+    return (
+      <OverlayTrigger
+        placement="bottom"
+        container={this.props.faucetContext.getContainer()}
+        overlay={this.renderInfoTooltip() as OverlayChildren}
+      >
+        <span className="auth-info-icon">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="bi bi-info-circle" viewBox="0 0 16 16">
+            <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+            <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+          </svg>
+        </span>
+      </OverlayTrigger>
+    );
+  }
+
+  private renderInfoTooltip(): React.ReactElement {
+    let html = this.props.faucetConfig.modules.authenticatoor.infoHtml;
+    if(!html)
+      return null;
+    return (
+      <Tooltip id="authenticatoor-tooltip">
+        <div className='authenticatoor-info' dangerouslySetInnerHTML={{__html: html}}></div>
+      </Tooltip>
+    );
+  }
+
+  public getToken(): string | null {
+    let client = window.ethpandaops?.authenticatoor;
+    return client ? client.getToken() : null;
+  }
+
+  private onLoginClick() {
+    let client = window.ethpandaops?.authenticatoor;
+    if(!client)
+      return;
+    client.login();
+  }
+
+  private onLogoutClick() {
+    let client = window.ethpandaops?.authenticatoor;
+    if(client)
+      client.logout();
+    this.setState({
+      loginInfo: { authenticated: false, token: "", exp: 0, user: "" },
+    });
+  }
+
+}

--- a/faucet-client/src/components/frontpage/authenticatoor/index.ts
+++ b/faucet-client/src/components/frontpage/authenticatoor/index.ts
@@ -1,0 +1,1 @@
+export { AuthenticatoorLogin } from './AuthenticatoorLogin';

--- a/faucet-client/src/main.ts
+++ b/faucet-client/src/main.ts
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import { createRoot } from 'react-dom/client';
 import { FaucetPage, IFaucetPageProps } from './components/FaucetPage';
+import { captureAuthenticatoorFragment } from './common/AuthenticatoorFragment';
 import * as powfaucet from '.'
 
 export function initializeFaucet(container: Element, faucetProps: IFaucetPageProps): { element: ReactElement, instance: FaucetPage } {
@@ -21,6 +22,13 @@ export function initializeFaucet(container: Element, faucetProps: IFaucetPagePro
 }
 
 (() => {
+  // Authenticatoor's /auth/login redirect lands back on us with
+  // #auth_token=…&exp=…&user=… in the URL fragment. The faucet uses a
+  // HashRouter, so an unhandled fragment becomes a phantom route and
+  // nothing renders. Strip those params (and stash the token to
+  // sessionStorage with the same keys client.js uses) before React mounts.
+  captureAuthenticatoorFragment();
+
   let PoWFaucet = (window as any).PoWFaucet = {
     ...powfaucet,
     page: null,

--- a/faucet-config.example.yaml
+++ b/faucet-config.example.yaml
@@ -245,10 +245,20 @@ modules:
     # script injection (<authUrl>/client.js).
     authUrl: "https://auth.example.com"
 
-    # expected aud claim. Tokens issued by authenticatoor carry the bare
-    # hostname of the protected service in the aud claim — set this to the
-    # faucet's public hostname (no scheme, no port).
-    expectedAudience: "faucet.example.com"
+    # expected aud claim. By default authenticatoor derives the audience from
+    # its issuer URL by stripping the leftmost label — so an issuer at
+    # https://auth.example.com produces tokens with aud = "example.com",
+    # shared across every service in that parent zone. Set this to whatever
+    # value the authenticatoor's `audience` config resolves to (its parent
+    # zone unless overridden).
+    expectedAudience: "example.com"
+
+    # optional defense-in-depth: when set, the token's `scope` wildcard
+    # pattern must match this host (DNS-label glob, same rules as the auth
+    # service). Use the faucet's public hostname (no scheme, no port).
+    # Tokens without a scope claim are accepted regardless. Leave null to
+    # rely on the audience pin alone.
+    expectedHost: null # e.g. "faucet.example.com"
 
     # require login to start a session. When false the module is purely
     # opt-in and only applies grants when a user is authenticated.

--- a/faucet-config.example.yaml
+++ b/faucet-config.example.yaml
@@ -235,6 +235,55 @@ modules:
     lowerLimit: -500000000000000000000 # -500 ETH (when outflow balance gets smaller or equal to this, the reward will be 0%)
     upperLimit: 500000000000000000000 # 500 ETH
 
+  ## Authenticatoor login (ethpandaops/service-authenticatoor)
+  authenticatoor:
+    # enable / disable authenticatoor login
+    enabled: false
+
+    # base URL of the authenticatoor service. Used for both backend JWKS
+    # verification (<authUrl>/.well-known/openid-configuration) and frontend
+    # script injection (<authUrl>/client.js).
+    authUrl: "https://auth.example.com"
+
+    # expected aud claim. Tokens issued by authenticatoor carry the bare
+    # hostname of the protected service in the aud claim — set this to the
+    # faucet's public hostname (no scheme, no port).
+    expectedAudience: "faucet.example.com"
+
+    # require login to start a session. When false the module is purely
+    # opt-in and only applies grants when a user is authenticated.
+    requireLogin: false
+
+    # max concurrent sessions per authenticated user (0 = unlimited)
+    concurrencyLimit: 0
+
+    # recurring grants applied on session start. Evaluated in order; later
+    # grants override perks of earlier ones. Use grants without limits as
+    # the always-on baseline for logged-in users, and stricter grants as
+    # tier-specific bonuses.
+    grants:
+      # baseline grant for any authenticated user — double reward
+      - limitCount: 0
+        limitAmount: 0
+        duration: 86400 # 1 day
+        rewardFactor: 2
+
+      # static drop without mining: 0.5 ETH max once per day, skips PoW.
+      # Once consumed the user falls back to the previous grant tier.
+      - limitCount: 1
+        duration: 86400 # 1 day
+        skipModules: ["pow", "recurring-limits", "faucet-outflow"]
+        overrideMaxDrop: 500000000000000000 # 0.5 ETH
+
+    # frontend customization
+    loginLabel: "Login for additional benefits"
+    userLabel: "Authenticated"
+    loginLogo: null
+    infoHtml: |
+      <strong>Authenticated users get:</strong><br>
+      - 2x reward factor<br>
+      - 1 free static drop per day (no mining)
+
   ## Github login protection
   github:
     # enable / disable github login protection

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "commander": "^14.0.0",
         "hcaptcha": "^0.2.0",
         "html-entities": "^2.5.2",
+        "jose": "^6.2.3",
         "json-bigint": "^1.0.0",
         "mysql2": "^3.11.0",
         "node-fetch": "^3.3.2",
@@ -3173,6 +3174,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "commander": "^14.0.0",
     "hcaptcha": "^0.2.0",
     "html-entities": "^2.5.2",
+    "jose": "^6.2.3",
     "json-bigint": "^1.0.0",
     "mysql2": "^3.11.0",
     "node-fetch": "^3.3.2",

--- a/src/modules/MODULE_HOOKS.md
+++ b/src/modules/MODULE_HOOKS.md
@@ -1,10 +1,10 @@
 
 ClientConfig
-    prio 1: captcha, ensname, github, passport, pow, zupass
+    prio 1: authenticatoor, captcha, ensname, github, passport, pow, zupass
 
 SessionStart
     prio 1: captcha, *maintenance_mode_check
-    prio 2: whitelist, zupass
+    prio 2: authenticatoor, whitelist, zupass
     prio 3: ensname
     prio 5: *eth_address_check
     prio 6: passport
@@ -18,7 +18,7 @@ SessionInfo
     prio 1: passport, pow
 
 SessionRewardFactor
-    prio 5: faucet-outflow, github, passport
+    prio 5: authenticatoor, faucet-outflow, github, passport
     prio 6: faucet-balance, ipinfo, whitelist
 
 SessionRewarded
@@ -29,7 +29,7 @@ SessionIpChange
     prio 6: concurrency-limit, ipinfo
 
 SessionComplete
-    prio 5: github
+    prio 5: authenticatoor, github
     prio 10: pow
 
 SessionClaim

--- a/src/modules/authenticatoor/AuthenticatoorConfig.ts
+++ b/src/modules/authenticatoor/AuthenticatoorConfig.ts
@@ -1,0 +1,37 @@
+import { IBaseModuleConfig } from "../BaseModule.js";
+
+export interface IAuthenticatoorConfig extends IBaseModuleConfig {
+  authUrl: string;
+  expectedAudience: string | null;
+  requireLogin: boolean;
+  concurrencyLimit: number;
+  grants: IAuthenticatoorGrantConfig[];
+  loginLabel: string | null;
+  userLabel: string | null;
+  infoHtml: string | null;
+  loginLogo: string | null;
+}
+
+export interface IAuthenticatoorGrantConfig {
+  limitCount: number;
+  limitAmount: number;
+  duration: number;
+  skipModules?: string[];
+  rewardFactor?: number;
+  overrideMaxDrop?: number;
+  required?: boolean;
+  message?: string;
+}
+
+export const defaultConfig: IAuthenticatoorConfig = {
+  enabled: false,
+  authUrl: "",
+  expectedAudience: null,
+  requireLogin: false,
+  concurrencyLimit: 0,
+  grants: [],
+  loginLabel: null,
+  userLabel: null,
+  infoHtml: null,
+  loginLogo: null,
+}

--- a/src/modules/authenticatoor/AuthenticatoorConfig.ts
+++ b/src/modules/authenticatoor/AuthenticatoorConfig.ts
@@ -3,6 +3,7 @@ import { IBaseModuleConfig } from "../BaseModule.js";
 export interface IAuthenticatoorConfig extends IBaseModuleConfig {
   authUrl: string;
   expectedAudience: string | null;
+  expectedHost: string | null;
   requireLogin: boolean;
   concurrencyLimit: number;
   grants: IAuthenticatoorGrantConfig[];
@@ -27,6 +28,7 @@ export const defaultConfig: IAuthenticatoorConfig = {
   enabled: false,
   authUrl: "",
   expectedAudience: null,
+  expectedHost: null,
   requireLogin: false,
   concurrencyLimit: 0,
   grants: [],

--- a/src/modules/authenticatoor/AuthenticatoorDB.ts
+++ b/src/modules/authenticatoor/AuthenticatoorDB.ts
@@ -1,0 +1,77 @@
+import { FaucetDbDriver } from '../../db/FaucetDatabase.js';
+import { FaucetModuleDB } from '../../db/FaucetModuleDB.js';
+import { SQL } from '../../db/SQL.js';
+import { FaucetSessionStoreData } from '../../session/FaucetSession.js';
+
+export class AuthenticatoorDB extends FaucetModuleDB {
+  protected override latestSchemaVersion = 1;
+
+  protected override async upgradeSchema(version: number): Promise<number> {
+    switch(version) {
+      case 0:
+        version = 1;
+        await this.db.exec(SQL.driverSql({
+          [FaucetDbDriver.SQLITE]: `
+            CREATE TABLE "AuthenticatoorSessions" (
+              "SessionId" TEXT NOT NULL UNIQUE,
+              "UserId" TEXT NOT NULL,
+              "Issuer" TEXT NOT NULL,
+              PRIMARY KEY("SessionId")
+            );`,
+          [FaucetDbDriver.MYSQL]: `
+            CREATE TABLE AuthenticatoorSessions (
+              SessionId CHAR(36) NOT NULL,
+              UserId VARCHAR(190) NOT NULL,
+              Issuer VARCHAR(190) NOT NULL,
+              PRIMARY KEY(SessionId)
+            );`,
+        }));
+        await this.db.exec(SQL.driverSql({
+          [FaucetDbDriver.SQLITE]: `CREATE INDEX "AuthenticatoorSessionsUserIdx" ON "AuthenticatoorSessions" ("UserId" ASC);`,
+          [FaucetDbDriver.MYSQL]: `ALTER TABLE AuthenticatoorSessions ADD INDEX AuthenticatoorSessionsUserIdx (UserId);`,
+        }));
+    }
+    return version;
+  }
+
+  public override async cleanStore(): Promise<void> {
+    let rows = await this.db.all([
+      "SELECT AuthenticatoorSessions.SessionId",
+      "FROM AuthenticatoorSessions",
+      "LEFT JOIN Sessions ON Sessions.SessionId = AuthenticatoorSessions.SessionId",
+      "WHERE Sessions.SessionId IS NULL",
+    ].join(" "));
+    let dataIdx = 0;
+    let promises: Promise<void>[] = [];
+    while(dataIdx < rows.length) {
+      let batchLen = Math.min(rows.length - dataIdx, 100);
+      let dataBatch = rows.slice(dataIdx, dataIdx + batchLen);
+      dataIdx += batchLen;
+      promises.push(this.db.run(
+        "DELETE FROM AuthenticatoorSessions WHERE SessionId IN (" + dataBatch.map(b => "?").join(",") + ")",
+        dataBatch.map(b => b.SessionId) as any[]
+      ).then())
+    }
+    await Promise.all(promises);
+  }
+
+  public getUserSessions(userId: string, duration: number, skipData?: boolean): Promise<FaucetSessionStoreData[]> {
+    let now = this.now();
+    return this.faucetStore.selectSessionsSql([
+      "FROM AuthenticatoorSessions",
+      "INNER JOIN Sessions ON Sessions.SessionId = AuthenticatoorSessions.SessionId",
+      "WHERE AuthenticatoorSessions.UserId = ? AND Sessions.StartTime > ? AND Sessions.Status IN ('claimable','claiming','finished')",
+    ].join(" "), [ userId, now - duration ], skipData);
+  }
+
+  public async setUserSession(sessionId: string, userId: string, issuer: string): Promise<void> {
+    await this.db.run(
+      SQL.driverSql({
+        [FaucetDbDriver.SQLITE]: "INSERT OR REPLACE INTO AuthenticatoorSessions (SessionId,UserId,Issuer) VALUES (?,?,?)",
+        [FaucetDbDriver.MYSQL]: "REPLACE INTO AuthenticatoorSessions (SessionId,UserId,Issuer) VALUES (?,?,?)",
+      }),
+      [ sessionId, userId, issuer ]
+    );
+  }
+
+}

--- a/src/modules/authenticatoor/AuthenticatoorModule.ts
+++ b/src/modules/authenticatoor/AuthenticatoorModule.ts
@@ -1,0 +1,219 @@
+import { ServiceManager } from "../../common/ServiceManager.js";
+import { EthWalletManager } from "../../eth/EthWalletManager.js";
+import { FaucetSession } from "../../session/FaucetSession.js";
+import { BaseModule } from "../BaseModule.js";
+import { ModuleHookAction } from "../ModuleManager.js";
+import { defaultConfig, IAuthenticatoorConfig, IAuthenticatoorGrantConfig } from './AuthenticatoorConfig.js';
+import { FaucetError } from '../../common/FaucetError.js';
+import { FaucetDatabase } from "../../db/FaucetDatabase.js";
+import { renderTimespan } from "../../utils/DateUtils.js";
+import { FaucetLogLevel, FaucetProcess } from "../../common/FaucetProcess.js";
+import { ISessionRewardFactor } from "../../session/SessionRewardFactor.js";
+import { SessionManager } from "../../session/SessionManager.js";
+import { AuthenticatoorVerifier, IAuthenticatoorClaims } from './AuthenticatoorVerifier.js';
+import { AuthenticatoorDB } from './AuthenticatoorDB.js';
+
+export interface IAuthenticatoorAuthInfo {
+  userId: string;
+  email: string;
+  issuer: string;
+}
+
+export interface AuthenticatoorGrantPerks {
+  factor?: number;
+  skipModules?: string[];
+  overrideMaxDrop?: number;
+}
+
+export class AuthenticatoorModule extends BaseModule<IAuthenticatoorConfig> {
+  protected readonly moduleDefaultConfig = defaultConfig;
+  private authDb: AuthenticatoorDB;
+  private verifier: AuthenticatoorVerifier;
+
+  protected override async startModule(): Promise<void> {
+    this.authDb = await ServiceManager.GetService(FaucetDatabase).createModuleDb(AuthenticatoorDB, this);
+    this.initVerifier();
+
+    this.moduleManager.addActionHook(
+      this, ModuleHookAction.ClientConfig, 1, "authenticatoor login config",
+      async (clientConfig: any) => {
+        clientConfig[this.moduleName] = {
+          authUrl: this.moduleConfig.authUrl,
+          requireLogin: this.moduleConfig.requireLogin,
+          loginLabel: this.moduleConfig.loginLabel,
+          userLabel: this.moduleConfig.userLabel,
+          infoHtml: this.moduleConfig.infoHtml,
+          loginLogo: this.moduleConfig.loginLogo,
+        };
+      }
+    );
+    this.moduleManager.addActionHook(
+      this, ModuleHookAction.SessionStart, 2, "authenticatoor login check",
+      (session: FaucetSession, userInput: any) => this.processSessionStart(session, userInput)
+    );
+    this.moduleManager.addActionHook(
+      this, ModuleHookAction.SessionComplete, 5, "authenticatoor save session",
+      (session: FaucetSession) => this.processSessionComplete(session)
+    );
+    this.moduleManager.addActionHook(
+      this, ModuleHookAction.SessionRewardFactor, 5, "authenticatoor reward factor",
+      (session: FaucetSession, rewardFactors: ISessionRewardFactor[]) => this.processSessionRewardFactor(session, rewardFactors)
+    );
+  }
+
+  protected override stopModule(): Promise<void> {
+    this.verifier = null;
+    return Promise.resolve();
+  }
+
+  protected override onConfigReload(): void {
+    this.initVerifier();
+  }
+
+  private initVerifier(): void {
+    if(!this.moduleConfig.authUrl) {
+      ServiceManager.GetService(FaucetProcess).emitLog(FaucetLogLevel.WARNING, "authenticatoor module enabled but no authUrl configured; tokens cannot be verified");
+      this.verifier = null;
+      return;
+    }
+    let audience = this.moduleConfig.expectedAudience;
+    if(!audience) {
+      ServiceManager.GetService(FaucetProcess).emitLog(FaucetLogLevel.WARNING, "authenticatoor module: expectedAudience is not configured; verification will fail until set");
+    }
+    this.verifier = new AuthenticatoorVerifier(this.moduleConfig.authUrl, audience || "");
+  }
+
+  private async processSessionStart(session: FaucetSession, userInput: any): Promise<void> {
+    if(session.getSessionData<Array<string>>("skip.modules", []).indexOf(this.moduleName) !== -1)
+      return;
+
+    let authInfo: IAuthenticatoorAuthInfo | null = null;
+    if(userInput.authToken && this.verifier) {
+      try {
+        let claims = await this.verifier.verify(userInput.authToken);
+        authInfo = this.claimsToAuthInfo(claims);
+      } catch(ex) {
+        ServiceManager.GetService(FaucetProcess).emitLog(FaucetLogLevel.WARNING, "Error verifying authenticatoor token: " + ex.toString());
+        throw new FaucetError("AUTHENTICATOOR_TOKEN", "Invalid authenticatoor login token.");
+      }
+    }
+
+    if(this.moduleConfig.requireLogin && !authInfo) {
+      throw new FaucetError("AUTHENTICATOOR_REQUIRED", "You need to authenticate to use this faucet.");
+    }
+
+    if(authInfo) {
+      this.checkConcurrencyLimit(authInfo, session);
+
+      let perks: AuthenticatoorGrantPerks = {};
+      for(let i = 0; i < this.moduleConfig.grants.length; i++) {
+        await this.checkGrant(authInfo, this.moduleConfig.grants[i], perks);
+      }
+
+      session.setSessionData("authenticatoor.data", authInfo);
+      if(typeof perks.factor === "number")
+        session.setSessionData("authenticatoor.factor", perks.factor);
+      if(typeof perks.overrideMaxDrop === "number") {
+        session.setSessionData("overrideMaxDropAmount", perks.overrideMaxDrop.toString());
+        session.setDropAmount(BigInt(perks.overrideMaxDrop));
+      }
+      if(perks.skipModules) {
+        let skipModules = session.getSessionData<Array<string>>("skip.modules", []);
+        perks.skipModules.forEach((mod) => {
+          if(!mod)
+            return;
+          if(skipModules.indexOf(mod) === -1)
+            skipModules.push(mod);
+        });
+        session.setSessionData("skip.modules", skipModules);
+      }
+    }
+  }
+
+  private async processSessionComplete(session: FaucetSession): Promise<void> {
+    let authInfo = session.getSessionData<IAuthenticatoorAuthInfo>("authenticatoor.data");
+    if(!authInfo)
+      return;
+    await this.authDb.setUserSession(session.getSessionId(), authInfo.userId, authInfo.issuer);
+  }
+
+  private async processSessionRewardFactor(session: FaucetSession, rewardFactors: ISessionRewardFactor[]): Promise<void> {
+    let factor = session.getSessionData("authenticatoor.factor");
+    if(typeof factor !== "number")
+      return;
+    rewardFactors.push({
+      factor: factor,
+      module: this.moduleName,
+    });
+  }
+
+  private claimsToAuthInfo(claims: IAuthenticatoorClaims): IAuthenticatoorAuthInfo {
+    let userId = claims.email || (claims.sub as string) || "";
+    if(!userId)
+      throw new Error("token has no email or sub claim");
+    return {
+      userId: userId,
+      email: claims.email || "",
+      issuer: (claims.iss as string) || "",
+    };
+  }
+
+  private checkConcurrencyLimit(authInfo: IAuthenticatoorAuthInfo, session: FaucetSession): void {
+    if(this.moduleConfig.concurrencyLimit === 0)
+      return;
+    let activeSessions = ServiceManager.GetService(SessionManager).getActiveSessions();
+    let concurrent = activeSessions.filter((sess) => {
+      if(sess === session)
+        return false;
+      let info = sess.getSessionData<IAuthenticatoorAuthInfo>("authenticatoor.data");
+      return info && info.userId === authInfo.userId;
+    }).length;
+    if(concurrent >= this.moduleConfig.concurrencyLimit) {
+      throw new FaucetError(
+        "AUTHENTICATOOR_CONCURRENCY_LIMIT",
+        "Only " + this.moduleConfig.concurrencyLimit + " concurrent sessions allowed per authenticated user.",
+      );
+    }
+  }
+
+  private async checkGrant(authInfo: IAuthenticatoorAuthInfo, grant: IAuthenticatoorGrantConfig, perks: AuthenticatoorGrantPerks): Promise<void> {
+    let finishedSessions = await this.authDb.getUserSessions(authInfo.userId, grant.duration, true);
+
+    if(grant.limitCount > 0 && finishedSessions.length >= grant.limitCount) {
+      if(!grant.required)
+        return;
+      let errMsg = grant.message || [
+        "You have already created ",
+        finishedSessions.length,
+        (finishedSessions.length > 1 ? " sessions" : " session"),
+        " in the last ",
+        renderTimespan(grant.duration),
+      ].join("");
+      throw new FaucetError("AUTHENTICATOOR_LIMIT", errMsg);
+    }
+
+    if(grant.limitAmount > 0) {
+      let totalAmount = 0n;
+      finishedSessions.forEach((sess) => totalAmount += BigInt(sess.dropAmount));
+      if(totalAmount >= BigInt(grant.limitAmount)) {
+        if(!grant.required)
+          return;
+        let errMsg = grant.message || [
+          "You have already requested ",
+          ServiceManager.GetService(EthWalletManager).readableAmount(totalAmount),
+          " in the last ",
+          renderTimespan(grant.duration),
+        ].join("");
+        throw new FaucetError("AUTHENTICATOOR_LIMIT", errMsg);
+      }
+    }
+
+    if(grant.skipModules)
+      perks.skipModules = grant.skipModules;
+    if(typeof grant.rewardFactor === "number")
+      perks.factor = grant.rewardFactor;
+    if(typeof grant.overrideMaxDrop !== "undefined")
+      perks.overrideMaxDrop = grant.overrideMaxDrop;
+  }
+
+}

--- a/src/modules/authenticatoor/AuthenticatoorModule.ts
+++ b/src/modules/authenticatoor/AuthenticatoorModule.ts
@@ -80,7 +80,7 @@ export class AuthenticatoorModule extends BaseModule<IAuthenticatoorConfig> {
     if(!audience) {
       ServiceManager.GetService(FaucetProcess).emitLog(FaucetLogLevel.WARNING, "authenticatoor module: expectedAudience is not configured; verification will fail until set");
     }
-    this.verifier = new AuthenticatoorVerifier(this.moduleConfig.authUrl, audience || "");
+    this.verifier = new AuthenticatoorVerifier(this.moduleConfig.authUrl, audience || "", this.moduleConfig.expectedHost || "");
   }
 
   private async processSessionStart(session: FaucetSession, userInput: any): Promise<void> {

--- a/src/modules/authenticatoor/AuthenticatoorVerifier.ts
+++ b/src/modules/authenticatoor/AuthenticatoorVerifier.ts
@@ -9,16 +9,62 @@ export interface IAuthenticatoorClaims extends JWTPayload {
   services?: string;
 }
 
+// matchHost mirrors authenticatoor's pkg/auth.MatchHost: a DNS-label glob.
+// "foo.bar" matches only "foo.bar"; "*.foo.bar" matches "x.foo.bar" and
+// "x.y.foo.bar" but not "foo.bar" (leading "*" requires at least one
+// label) and not "evil-foo.bar" (label boundary enforced); "*" matches
+// anything. Partial and non-leading wildcards are not supported.
+export function matchHost(pattern: string, host: string): boolean {
+  pattern = (pattern || "").toLowerCase().trim();
+  host = (host || "").toLowerCase().trim();
+  if(!pattern || !host)
+    return false;
+  if(pattern === "*")
+    return true;
+
+  let pl = pattern.split(".");
+  let hl = host.split(".");
+
+  for(let i = 0; i < pl.length; i++) {
+    let l = pl[i];
+    if(l === "*" && i !== 0)
+      return false;
+    if(l.indexOf("*") !== -1 && l !== "*")
+      return false;
+  }
+
+  if(pl[0] === "*") {
+    let suffix = pl.slice(1);
+    if(hl.length <= suffix.length)
+      return false;
+    for(let i = 0; i < suffix.length; i++) {
+      if(suffix[suffix.length - 1 - i] !== hl[hl.length - 1 - i])
+        return false;
+    }
+    return true;
+  }
+
+  if(pl.length !== hl.length)
+    return false;
+  for(let i = 0; i < pl.length; i++) {
+    if(pl[i] !== hl[i])
+      return false;
+  }
+  return true;
+}
+
 export class AuthenticatoorVerifier {
   private authUrl: string;
   private expectedAudience: string;
+  private expectedHost: string;
   private issuer: string;
   private jwks: ReturnType<typeof createRemoteJWKSet>;
   private discoveryPromise: Promise<void>;
 
-  public constructor(authUrl: string, expectedAudience: string) {
+  public constructor(authUrl: string, expectedAudience: string, expectedHost?: string) {
     this.authUrl = authUrl.replace(/\/+$/, "");
     this.expectedAudience = expectedAudience;
+    this.expectedHost = expectedHost || "";
   }
 
   private async ensureDiscovered(): Promise<void> {
@@ -56,6 +102,16 @@ export class AuthenticatoorVerifier {
       audience: this.expectedAudience,
       algorithms: ["RS256"],
     });
-    return payload as IAuthenticatoorClaims;
+    let claims = payload as IAuthenticatoorClaims;
+
+    // When expectedHost is configured, enforce that the token's scope
+    // wildcard pattern matches our host. Tokens without a scope claim
+    // fall through unchecked — the audience pin is the floor of trust.
+    if(this.expectedHost && claims.scope) {
+      if(!matchHost(claims.scope, this.expectedHost))
+        throw new Error("scope " + JSON.stringify(claims.scope) + " does not match host " + JSON.stringify(this.expectedHost));
+    }
+
+    return claims;
   }
 }

--- a/src/modules/authenticatoor/AuthenticatoorVerifier.ts
+++ b/src/modules/authenticatoor/AuthenticatoorVerifier.ts
@@ -1,0 +1,61 @@
+import { createRemoteJWKSet, customFetch, jwtVerify, JWTPayload } from "jose";
+import { ServiceManager } from "../../common/ServiceManager.js";
+import { FaucetLogLevel, FaucetProcess } from "../../common/FaucetProcess.js";
+import { FetchUtil } from "../../utils/FetchUtil.js";
+
+export interface IAuthenticatoorClaims extends JWTPayload {
+  email?: string;
+  scope?: string;
+  services?: string;
+}
+
+export class AuthenticatoorVerifier {
+  private authUrl: string;
+  private expectedAudience: string;
+  private issuer: string;
+  private jwks: ReturnType<typeof createRemoteJWKSet>;
+  private discoveryPromise: Promise<void>;
+
+  public constructor(authUrl: string, expectedAudience: string) {
+    this.authUrl = authUrl.replace(/\/+$/, "");
+    this.expectedAudience = expectedAudience;
+  }
+
+  private async ensureDiscovered(): Promise<void> {
+    if(this.jwks)
+      return;
+    if(!this.discoveryPromise) {
+      this.discoveryPromise = this.discover().catch((err) => {
+        // Reset so a later call can retry instead of being stuck on a failed promise.
+        this.discoveryPromise = null;
+        throw err;
+      });
+    }
+    await this.discoveryPromise;
+  }
+
+  private async discover(): Promise<void> {
+    let discoveryUrl = this.authUrl + "/.well-known/openid-configuration";
+    let response = await FetchUtil.fetch(discoveryUrl);
+    if(!response.ok)
+      throw new Error("authenticatoor discovery failed: HTTP " + response.status);
+    let doc = await response.json() as { issuer?: string, jwks_uri?: string };
+    if(!doc.issuer || !doc.jwks_uri)
+      throw new Error("authenticatoor discovery: missing issuer or jwks_uri");
+    this.issuer = doc.issuer;
+    this.jwks = createRemoteJWKSet(new URL(doc.jwks_uri), {
+      [customFetch]: ((url: any, init: any) => FetchUtil.fetch(url, init)) as any,
+    });
+    ServiceManager.GetService(FaucetProcess).emitLog(FaucetLogLevel.INFO, "authenticatoor discovered: issuer=" + this.issuer + " jwks=" + doc.jwks_uri);
+  }
+
+  public async verify(token: string): Promise<IAuthenticatoorClaims> {
+    await this.ensureDiscovered();
+    let { payload } = await jwtVerify(token, this.jwks, {
+      issuer: this.issuer,
+      audience: this.expectedAudience,
+      algorithms: ["RS256"],
+    });
+    return payload as IAuthenticatoorClaims;
+  }
+}

--- a/src/modules/modules.ts
+++ b/src/modules/modules.ts
@@ -1,3 +1,4 @@
+import { AuthenticatoorModule } from "./authenticatoor/AuthenticatoorModule.js";
 import { CaptchaModule } from "./captcha/CaptchaModule.js";
 import { ConcurrencyLimitModule } from "./concurrency-limit/ConcurrencyLimitModule.js";
 import { EnsNameModule } from "./ensname/EnsNameModule.js";
@@ -15,6 +16,7 @@ import { WhitelistModule } from "./whitelist/WhitelistModule.js";
 import { ZupassModule } from "./zupass/ZupassModule.js";
 
 export const MODULE_CLASSES = {
+  "authenticatoor": AuthenticatoorModule,
   "captcha": CaptchaModule,
   "concurrency-limit": ConcurrencyLimitModule,
   "ensname": EnsNameModule,

--- a/tests/modules/AuthenticatoorModule.spec.ts
+++ b/tests/modules/AuthenticatoorModule.spec.ts
@@ -50,6 +50,7 @@ describe("Faucet module: authenticatoor (module)", () => {
       enabled: true,
       authUrl: AUTH_URL,
       expectedAudience: AUDIENCE,
+      expectedHost: null,
       requireLogin: false,
       concurrencyLimit: 0,
       grants: [],
@@ -81,6 +82,13 @@ describe("Faucet module: authenticatoor (module)", () => {
     expect((mod as any).grants).to.equal(undefined, "grants leaked to client config");
     expect((mod as any).concurrencyLimit).to.equal(undefined, "concurrencyLimit leaked to client config");
     expect((mod as any).expectedAudience).to.equal(undefined, "expectedAudience leaked to client config");
+  });
+
+  it("expectedHost is propagated to the verifier", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).expectedHost = "faucet.example.com";
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let mod = ServiceManager.GetService(ModuleManager).getModule<any>("authenticatoor");
+    expect(mod.verifier.expectedHost).to.equal("faucet.example.com");
   });
 
   it("Module reload reinitializes verifier", async () => {

--- a/tests/modules/AuthenticatoorModule.spec.ts
+++ b/tests/modules/AuthenticatoorModule.spec.ts
@@ -1,0 +1,464 @@
+import 'mocha';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { bindTestStubs, unbindTestStubs, loadDefaultTestConfig } from '../common.js';
+import { sleepPromise } from '../../src/utils/PromiseUtils.js';
+import { ServiceManager } from '../../src/common/ServiceManager.js';
+import { FaucetDatabase } from '../../src/db/FaucetDatabase.js';
+import { ModuleHookAction, ModuleManager } from '../../src/modules/ModuleManager.js';
+import { SessionManager } from '../../src/session/SessionManager.js';
+import { faucetConfig } from '../../src/config/FaucetConfig.js';
+import { FaucetError } from '../../src/common/FaucetError.js';
+import { FaucetWebApi } from '../../src/webserv/FaucetWebApi.js';
+import { FaucetSession, FaucetSessionStatus } from '../../src/session/FaucetSession.js';
+import { IAuthenticatoorConfig } from '../../src/modules/authenticatoor/AuthenticatoorConfig.js';
+import { AuthenticatoorVerifier, IAuthenticatoorClaims } from '../../src/modules/authenticatoor/AuthenticatoorVerifier.js';
+import { AuthenticatoorDB } from '../../src/modules/authenticatoor/AuthenticatoorDB.js';
+
+const AUTH_URL = "http://auth.test.local";
+const AUDIENCE = "faucet.test.local";
+
+function tokenFor(email: string): string {
+  // Tokens never reach the verifier — the stub keys off this label string.
+  return "stub.token." + email;
+}
+
+describe("Faucet module: authenticatoor (module)", () => {
+  let globalStubs;
+  let verifyStub: sinon.SinonStub;
+
+  beforeEach(async () => {
+    verifyStub = sinon.stub(AuthenticatoorVerifier.prototype, "verify").callsFake(async (token: string) => {
+      let m = /^stub\.token\.(.+)$/.exec(token);
+      if(!m) throw new Error("verifier: bad token");
+      let email = m[1];
+      return {
+        sub: email,
+        email: email,
+        iss: AUTH_URL,
+        aud: AUDIENCE,
+        scope: "*." + AUDIENCE,
+      } as IAuthenticatoorClaims;
+    });
+
+    globalStubs = bindTestStubs({
+      "AuthenticatoorVerifier.verify": verifyStub,
+    });
+    loadDefaultTestConfig();
+    await ServiceManager.GetService(FaucetDatabase).initialize();
+    faucetConfig.modules["authenticatoor"] = {
+      enabled: true,
+      authUrl: AUTH_URL,
+      expectedAudience: AUDIENCE,
+      requireLogin: false,
+      concurrencyLimit: 0,
+      grants: [],
+      loginLabel: "Login for benefits",
+      userLabel: "Authenticated",
+      loginLogo: null,
+      infoHtml: "auth info",
+    } as IAuthenticatoorConfig;
+  });
+
+  afterEach(async () => {
+    let dbService = ServiceManager.GetService(FaucetDatabase);
+    await ServiceManager.DisposeAllServices();
+    await dbService.closeDatabase();
+    await unbindTestStubs(globalStubs);
+  });
+
+  it("Check client config exports", async () => {
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let clientConfig = ServiceManager.GetService(FaucetWebApi).onGetFaucetConfig();
+    let mod = clientConfig.modules['authenticatoor'];
+    expect(!!mod).to.equal(true, "no authenticatoor config exported");
+    expect(mod.authUrl).to.equal(AUTH_URL, "client config mismatch: authUrl");
+    expect(mod.requireLogin).to.equal(false, "client config mismatch: requireLogin");
+    expect(mod.loginLabel).to.equal("Login for benefits", "client config mismatch: loginLabel");
+    expect(mod.userLabel).to.equal("Authenticated", "client config mismatch: userLabel");
+    expect(mod.infoHtml).to.match(/auth info/, "client config mismatch: infoHtml");
+    // Internal fields like grants/concurrencyLimit must not leak to the client.
+    expect((mod as any).grants).to.equal(undefined, "grants leaked to client config");
+    expect((mod as any).concurrencyLimit).to.equal(undefined, "concurrencyLimit leaked to client config");
+    expect((mod as any).expectedAudience).to.equal(undefined, "expectedAudience leaked to client config");
+  });
+
+  it("Module reload reinitializes verifier", async () => {
+    await ServiceManager.GetService(ModuleManager).initialize();
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).expectedAudience = "new.aud";
+    let mod = ServiceManager.GetService(ModuleManager).getModule<any>("authenticatoor");
+    mod.onConfigReload();
+    expect(mod.verifier).to.not.equal(null, "verifier should be re-created");
+  });
+
+  it("Optional login: session starts without token (no auth data)", async () => {
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+    });
+    expect(testSession.getSessionStatus()).to.equal(FaucetSessionStatus.CLAIMABLE, "unexpected session status");
+    expect(testSession.getSessionData("authenticatoor.data")).to.equal(undefined, "authenticatoor.data set without token");
+    expect(verifyStub.callCount).to.equal(0, "verifier should not be called without token");
+  });
+
+  it("requireLogin: session without token is rejected", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).requireLogin = true;
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let error: FaucetError | null = null;
+    try {
+      await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+        addr: "0x0000000000000000000000000000000000001337",
+      });
+    } catch(ex) { error = ex; }
+    expect(error).to.not.equal(null, "no error thrown");
+    expect(error?.getCode()).to.equal("AUTHENTICATOOR_REQUIRED", "unexpected error code");
+  });
+
+  it("Invalid token is rejected", async () => {
+    await ServiceManager.GetService(ModuleManager).initialize();
+    verifyStub.rejects(new Error("verifier: bad signature"));
+    let error: FaucetError | null = null;
+    try {
+      await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+        addr: "0x0000000000000000000000000000000000001337",
+        authToken: "stub.token.alice@example.com",
+      });
+    } catch(ex) { error = ex; }
+    expect(error).to.not.equal(null, "no error thrown");
+    expect(error?.getCode()).to.equal("AUTHENTICATOOR_TOKEN", "unexpected error code");
+    expect(error?.message).to.match(/Invalid authenticatoor login token/, "unexpected error message");
+  });
+
+  it("Skipping authenticatoor module is honored", async () => {
+    await ServiceManager.GetService(ModuleManager).initialize();
+    ServiceManager.GetService(ModuleManager).addActionHook(null, ModuleHookAction.SessionStart, 1, "skip-test", (session: FaucetSession) => {
+      session.setSessionData("skip.modules", ["authenticatoor"]);
+    });
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(testSession.getSessionData("authenticatoor.data")).to.equal(undefined, "auth data set even though module was skipped");
+    expect(verifyStub.callCount).to.equal(0, "verifier should not be called when skipped");
+  });
+
+  it("Valid token: stores auth data and applies grant perks", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).grants.push({
+      duration: 3600,
+      limitAmount: 0,
+      limitCount: 0,
+      rewardFactor: 2,
+      overrideMaxDrop: 2000000000000000000,
+      skipModules: ["recurring-limits", "ipinfo"],
+    });
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(testSession.getSessionStatus()).to.equal(FaucetSessionStatus.CLAIMABLE, "unexpected session status");
+    let data = testSession.getSessionData<any>("authenticatoor.data");
+    expect(!!data).to.equal(true, "no auth data stored");
+    expect(data.userId).to.equal("alice@example.com", "userId mismatch");
+    expect(data.email).to.equal("alice@example.com", "email mismatch");
+    expect(data.issuer).to.equal(AUTH_URL, "issuer mismatch");
+    expect(testSession.getSessionData("authenticatoor.factor")).to.equal(2, "rewardFactor not stored");
+    expect(testSession.getSessionData("overrideMaxDropAmount")).to.equal("2000000000000000000", "overrideMaxDropAmount not stored");
+    // setDropAmount(N) routes through addReward, which applies the rewardFactor.
+    // The cap (overrideMaxDropAmount) clamps back down at claim time.
+    expect(testSession.getDropAmount()).to.equal(4000000000000000000n, "dropAmount mismatch (override * factor)");
+    let skipped = testSession.getSessionData<string[]>("skip.modules", []);
+    expect(skipped.indexOf("recurring-limits")).to.not.equal(-1, "skip.modules missing recurring-limits");
+    expect(skipped.indexOf("ipinfo")).to.not.equal(-1, "skip.modules missing ipinfo");
+  });
+
+  it("overrideMaxDrop without rewardFactor produces exact fixed drop", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).grants.push({
+      duration: 3600,
+      limitAmount: 0,
+      limitCount: 0,
+      overrideMaxDrop: 1500000000000000000,
+    });
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(testSession.getDropAmount()).to.equal(1500000000000000000n, "dropAmount should equal overrideMaxDrop without factor");
+    expect(testSession.getSessionData("overrideMaxDropAmount")).to.equal("1500000000000000000");
+  });
+
+  it("rewardFactor flows through SessionRewardFactor hook", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).grants.push({
+      duration: 3600,
+      limitAmount: 0,
+      limitCount: 0,
+      rewardFactor: 1.5,
+    });
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    let factors: any[] = [];
+    await ServiceManager.GetService(ModuleManager).processActionHooks([], ModuleHookAction.SessionRewardFactor, [testSession, factors]);
+    let factor = factors.find(f => f.module === "authenticatoor");
+    expect(!!factor).to.equal(true, "no authenticatoor factor in reward factors");
+    expect(factor.factor).to.equal(1.5, "factor value mismatch");
+  });
+
+  it("Token without email/sub is rejected", async () => {
+    verifyStub.callsFake(async () => ({} as IAuthenticatoorClaims));
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let error: FaucetError | null = null;
+    try {
+      await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+        addr: "0x0000000000000000000000000000000000001337",
+        authToken: "anything",
+      });
+    } catch(ex) { error = ex; }
+    expect(error).to.not.equal(null, "no error thrown");
+    expect(error?.getCode()).to.equal("AUTHENTICATOOR_TOKEN", "expected token rejection");
+  });
+
+  it("Token with sub but no email falls back to sub", async () => {
+    verifyStub.callsFake(async () => ({
+      sub: "subject-id-123",
+      iss: AUTH_URL,
+    } as IAuthenticatoorClaims));
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: "anything",
+    });
+    let data = testSession.getSessionData<any>("authenticatoor.data");
+    expect(data.userId).to.equal("subject-id-123", "userId should fall back to sub");
+    expect(data.email).to.equal("", "email should be empty when not in token");
+  });
+
+  it("Grants with limitCount enforce per-user count limit", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).grants.push({
+      duration: 3600,
+      limitAmount: 0,
+      limitCount: 1,
+      required: true,
+    });
+    await ServiceManager.GetService(ModuleManager).initialize();
+    // First session passes.
+    let s1 = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(s1.getSessionStatus()).to.equal(FaucetSessionStatus.CLAIMABLE);
+    // Second session for same user is rejected.
+    let error: FaucetError | null = null;
+    try {
+      await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+        addr: "0x0000000000000000000000000000000000001337",
+        authToken: tokenFor("alice@example.com"),
+      });
+    } catch(ex) { error = ex; }
+    expect(error?.getCode()).to.equal("AUTHENTICATOOR_LIMIT", "expected limit error");
+    expect(error?.message).to.match(/already created/, "unexpected error message");
+  });
+
+  it("Grants with limitCount + custom message use the custom message", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).grants.push({
+      duration: 3600,
+      limitAmount: 0,
+      limitCount: 1,
+      required: true,
+      message: "test_message_9842",
+    });
+    await ServiceManager.GetService(ModuleManager).initialize();
+    await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    let error: FaucetError | null = null;
+    try {
+      await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+        addr: "0x0000000000000000000000000000000000001337",
+        authToken: tokenFor("alice@example.com"),
+      });
+    } catch(ex) { error = ex; }
+    expect(error?.getCode()).to.equal("AUTHENTICATOOR_LIMIT");
+    expect(error?.message).to.match(/test_message_9842/, "custom message not used");
+  });
+
+  it("Grants with limitAmount enforce per-user amount limit", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).grants.push({
+      duration: 3600,
+      limitAmount: 1000000000000000000,
+      limitCount: 0,
+      required: true,
+    });
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let s1 = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(s1.getDropAmount()).to.equal(1000000000000000000n, "first session drop");
+    let error: FaucetError | null = null;
+    try {
+      await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+        addr: "0x0000000000000000000000000000000000001337",
+        authToken: tokenFor("alice@example.com"),
+      });
+    } catch(ex) { error = ex; }
+    expect(error?.getCode()).to.equal("AUTHENTICATOOR_LIMIT", "expected limit error");
+    expect(error?.message).to.match(/already requested/, "unexpected error message");
+  });
+
+  it("Grants without 'required' degrade to no-perks instead of throwing", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).grants.push({
+      duration: 3600,
+      limitAmount: 0,
+      limitCount: 1,
+      rewardFactor: 5,
+      // not required
+    }, {
+      duration: 3600,
+      limitAmount: 0,
+      limitCount: 0,
+      rewardFactor: 1.2,
+    });
+    await ServiceManager.GetService(ModuleManager).initialize();
+    // First session uses the limited grant (factor 5).
+    let s1 = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(s1.getSessionData("authenticatoor.factor")).to.equal(1.2, "second grant should override the spent first one");
+    // Second session: limited grant exceeds limit, falls through to baseline grant.
+    let s2 = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(s2.getSessionStatus()).to.equal(FaucetSessionStatus.CLAIMABLE, "session should still complete");
+    expect(s2.getSessionData("authenticatoor.factor")).to.equal(1.2, "factor should fall back to baseline");
+  });
+
+  it("Concurrency limit: rejects extra sessions for the same user", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).concurrencyLimit = 1;
+    await ServiceManager.GetService(ModuleManager).initialize();
+    // Add a blocking task so the first session stays "running" instead of completing.
+    ServiceManager.GetService(ModuleManager).addActionHook(null, ModuleHookAction.SessionStart, 100, "blocker", (session: FaucetSession) => {
+      session.addBlockingTask("test", "test", 1);
+    });
+    let s1 = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(s1.getSessionStatus()).to.equal(FaucetSessionStatus.RUNNING);
+    await sleepPromise(20);
+
+    let error: FaucetError | null = null;
+    try {
+      await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+        addr: "0x0000000000000000000000000000000000001337",
+        authToken: tokenFor("alice@example.com"),
+      });
+    } catch(ex) { error = ex; }
+    expect(error?.getCode()).to.equal("AUTHENTICATOOR_CONCURRENCY_LIMIT");
+    expect(error?.message).to.match(/concurrent sessions/, "unexpected error message");
+  });
+
+  it("Concurrency limit only counts other authenticated users", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).concurrencyLimit = 1;
+    await ServiceManager.GetService(ModuleManager).initialize();
+    ServiceManager.GetService(ModuleManager).addActionHook(null, ModuleHookAction.SessionStart, 100, "blocker", (session: FaucetSession) => {
+      session.addBlockingTask("test", "test", 1);
+    });
+    // Session A: alice (running)
+    await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    await sleepPromise(20);
+    // Session B: bob — should NOT trip alice's concurrency limit.
+    let s2 = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001338",
+      authToken: tokenFor("bob@example.com"),
+    });
+    expect(s2.getSessionStatus()).to.equal(FaucetSessionStatus.RUNNING, "bob should be unaffected by alice's limit");
+  });
+
+  it("SessionComplete persists user→session mapping in DB", async () => {
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(testSession.getSessionStatus()).to.equal(FaucetSessionStatus.CLAIMABLE);
+
+    let mod = ServiceManager.GetService(ModuleManager).getModule<any>("authenticatoor");
+    let db: AuthenticatoorDB = mod.authDb;
+    let rows = await db.getUserSessions("alice@example.com", 3600, true);
+    expect(rows.length).to.equal(1, "expected one persisted session for alice");
+    expect(rows[0].sessionId).to.equal(testSession.getSessionId(), "persisted session id mismatch");
+  });
+
+  it("SessionComplete is a no-op when no auth data stored", async () => {
+    await ServiceManager.GetService(ModuleManager).initialize();
+    // No token → no auth data → SessionComplete should not write anything.
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+    });
+    expect(testSession.getSessionStatus()).to.equal(FaucetSessionStatus.CLAIMABLE);
+    let mod = ServiceManager.GetService(ModuleManager).getModule<any>("authenticatoor");
+    let db: AuthenticatoorDB = mod.authDb;
+    let rows = await db.getUserSessions("alice@example.com", 3600, true);
+    expect(rows.length).to.equal(0, "no rows expected without auth data");
+  });
+
+  it("Database cleanStore removes orphaned rows", async () => {
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    let now = Math.floor(Date.now() / 1000);
+    await ServiceManager.GetService(FaucetDatabase).updateSession({
+      sessionId: testSession.getSessionId(),
+      status: FaucetSessionStatus.FINISHED,
+      startTime: now - faucetConfig.sessionCleanup - 10,
+      targetAddr: "0x0000000000000000000000000000000000001337",
+      dropAmount: "1337",
+      remoteIP: "8.8.8.8",
+      tasks: [],
+      data: {},
+      claim: null,
+    });
+
+    ServiceManager.GetService(FaucetDatabase).cleanStore();
+    await sleepPromise(50);
+
+    let mod = ServiceManager.GetService(ModuleManager).getModule<any>("authenticatoor");
+    let db: AuthenticatoorDB = mod.authDb;
+    await db.cleanStore();
+    let rows = await db.getUserSessions("alice@example.com", 99999999, true);
+    expect(rows.length).to.equal(0, "row should have been cleaned up");
+  });
+
+  it("expectedAudience missing: module still constructs verifier (with empty audience)", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).expectedAudience = null;
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let mod = ServiceManager.GetService(ModuleManager).getModule<any>("authenticatoor");
+    expect(mod.verifier).to.not.equal(null, "verifier should be created even without audience");
+  });
+
+  it("authUrl missing: module loads without verifier and rejects auth attempts", async () => {
+    (faucetConfig.modules["authenticatoor"] as IAuthenticatoorConfig).authUrl = "";
+    await ServiceManager.GetService(ModuleManager).initialize();
+    let mod = ServiceManager.GetService(ModuleManager).getModule<any>("authenticatoor");
+    expect(mod.verifier).to.equal(null, "verifier should be null without authUrl");
+    // With no verifier, presented tokens are silently ignored (treated as no token).
+    let testSession = await ServiceManager.GetService(SessionManager).createSession("::ffff:8.8.8.8", {
+      addr: "0x0000000000000000000000000000000000001337",
+      authToken: tokenFor("alice@example.com"),
+    });
+    expect(testSession.getSessionData("authenticatoor.data")).to.equal(undefined, "no auth data without verifier");
+    expect(verifyStub.callCount).to.equal(0, "verifier should not be called without authUrl");
+  });
+});

--- a/tests/modules/AuthenticatoorModule.spec.ts
+++ b/tests/modules/AuthenticatoorModule.spec.ts
@@ -24,7 +24,7 @@ function tokenFor(email: string): string {
 }
 
 describe("Faucet module: authenticatoor (module)", () => {
-  let globalStubs;
+  let globalStubs: any;
   let verifyStub: sinon.SinonStub;
 
   beforeEach(async () => {

--- a/tests/modules/AuthenticatoorVerifier.spec.ts
+++ b/tests/modules/AuthenticatoorVerifier.spec.ts
@@ -1,0 +1,204 @@
+import 'mocha';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { exportJWK, generateKeyPair, SignJWT, KeyObject } from 'jose';
+import { FetchUtil } from '../../src/utils/FetchUtil.js';
+import { bindTestStubs, unbindTestStubs, loadDefaultTestConfig } from '../common.js';
+import { ServiceManager } from '../../src/common/ServiceManager.js';
+import { AuthenticatoorVerifier } from '../../src/modules/authenticatoor/AuthenticatoorVerifier.js';
+
+interface IFakeFetchResponse {
+  url: RegExp;
+  rsp?: any;
+  json?: any;
+  fail?: boolean;
+  calls: { url: string; opts: any }[];
+}
+
+const AUTH_URL = "http://auth.test.local";
+const ISSUER = AUTH_URL;
+const AUDIENCE = "faucet.test.local";
+const KID = "test-key-1";
+
+describe("Faucet module: authenticatoor (verifier)", () => {
+  let globalStubs;
+  let fakeFetchResponses: IFakeFetchResponse[];
+  let privateKey: KeyObject;
+  let publicJWK: any;
+
+  before(async () => {
+    let kp = await generateKeyPair("RS256", { extractable: true });
+    privateKey = kp.privateKey as KeyObject;
+    publicJWK = await exportJWK(kp.publicKey);
+    publicJWK.kid = KID;
+    publicJWK.alg = "RS256";
+    publicJWK.use = "sig";
+  });
+
+  beforeEach(async () => {
+    fakeFetchResponses = [];
+    globalStubs = bindTestStubs({
+      "fetch": sinon.stub(FetchUtil, "fetch").callsFake(fakeFetch),
+    });
+    loadDefaultTestConfig();
+
+    addFakeFetchResponse({
+      url: /\.well-known\/openid-configuration$/,
+      json: {
+        issuer: ISSUER,
+        jwks_uri: AUTH_URL + "/jwks.json",
+      },
+      calls: [],
+    });
+    addFakeFetchResponse({
+      url: /\/jwks\.json$/,
+      json: { keys: [publicJWK] },
+      calls: [],
+    });
+  });
+
+  afterEach(async () => {
+    await ServiceManager.DisposeAllServices();
+    await unbindTestStubs(globalStubs);
+  });
+
+  function fakeFetch(url: any): Promise<any> {
+    for(let i = 0; i < fakeFetchResponses.length; i++) {
+      if(fakeFetchResponses[i].url.test(url)) {
+        if(!fakeFetchResponses[i].calls)
+          fakeFetchResponses[i].calls = [];
+        fakeFetchResponses[i].calls.push({ url: url, opts: undefined });
+        if(fakeFetchResponses[i].fail)
+          return Promise.reject(fakeFetchResponses[i].rsp);
+        return Promise.resolve(fakeFetchResponses[i].rsp);
+      }
+    }
+    return Promise.reject("no fake response for " + url);
+  }
+
+  function addFakeFetchResponse(opts: IFakeFetchResponse): IFakeFetchResponse {
+    if(opts.json && !opts.rsp) {
+      opts.rsp = {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(opts.json),
+      };
+    }
+    fakeFetchResponses.push(opts);
+    return opts;
+  }
+
+  async function mintToken(claims: { sub?: string, email?: string, aud?: string, iss?: string, exp?: number, scope?: string }): Promise<string> {
+    let signer = new SignJWT({
+      email: claims.email,
+      scope: claims.scope,
+    })
+      .setProtectedHeader({ alg: "RS256", kid: KID })
+      .setIssuer(claims.iss ?? ISSUER)
+      .setAudience(claims.aud ?? AUDIENCE)
+      .setSubject(claims.sub ?? "alice@example.com")
+      .setIssuedAt()
+      .setExpirationTime(claims.exp ?? Math.floor(Date.now() / 1000) + 1800);
+    return signer.sign(privateKey);
+  }
+
+  it("Verify valid token", async () => {
+    let token = await mintToken({ email: "alice@example.com" });
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let claims = await verifier.verify(token);
+    expect(claims.email).to.equal("alice@example.com", "claims.email mismatch");
+    expect(claims.sub).to.equal("alice@example.com", "claims.sub mismatch");
+    expect(claims.iss).to.equal(ISSUER, "claims.iss mismatch");
+  });
+
+  it("Verify caches discovery (one fetch per JWKS lookup, not per verify)", async () => {
+    let discovery = fakeFetchResponses[0];
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let token1 = await mintToken({ email: "alice@example.com" });
+    let token2 = await mintToken({ email: "bob@example.com" });
+    await verifier.verify(token1);
+    await verifier.verify(token2);
+    expect(discovery.calls.length).to.equal(1, "discovery should only be fetched once");
+  });
+
+  it("Reject token with wrong audience", async () => {
+    let token = await mintToken({ email: "alice@example.com", aud: "other.audience" });
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let err: Error | null = null;
+    try { await verifier.verify(token); } catch(ex) { err = ex; }
+    expect(err).to.not.equal(null, "no error thrown");
+    expect(err.message.toLowerCase()).to.match(/aud/, "expected aud-related error");
+  });
+
+  it("Reject token with wrong issuer", async () => {
+    let token = await mintToken({ email: "alice@example.com", iss: "https://other.issuer" });
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let err: Error | null = null;
+    try { await verifier.verify(token); } catch(ex) { err = ex; }
+    expect(err).to.not.equal(null, "no error thrown");
+    expect(err.message.toLowerCase()).to.match(/iss/, "expected iss-related error");
+  });
+
+  it("Reject expired token", async () => {
+    let token = await mintToken({ email: "alice@example.com", exp: Math.floor(Date.now() / 1000) - 60 });
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let err: Error | null = null;
+    try { await verifier.verify(token); } catch(ex) { err = ex; }
+    expect(err).to.not.equal(null, "no error thrown");
+    expect(err.message.toLowerCase()).to.match(/exp/, "expected exp-related error");
+  });
+
+  it("Reject tampered token", async () => {
+    let token = await mintToken({ email: "alice@example.com" });
+    let tampered = token.slice(0, -8) + "AAAAAAAA";
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let err: Error | null = null;
+    try { await verifier.verify(tampered); } catch(ex) { err = ex; }
+    expect(err).to.not.equal(null, "no error thrown");
+    expect(err.message.toLowerCase()).to.match(/signature/, "expected signature error");
+  });
+
+  it("Reject when discovery endpoint fails", async () => {
+    fakeFetchResponses[0].rsp = { ok: false, status: 502, json: () => Promise.resolve({}) };
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let err: Error | null = null;
+    try { await verifier.verify("any.token"); } catch(ex) { err = ex; }
+    expect(err).to.not.equal(null, "no error thrown");
+    expect(err.message).to.match(/discovery failed: HTTP 502/, "expected discovery http error");
+  });
+
+  it("Reject when discovery doc is missing fields", async () => {
+    fakeFetchResponses[0].rsp = { ok: true, status: 200, json: () => Promise.resolve({}) };
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let err: Error | null = null;
+    try { await verifier.verify("any.token"); } catch(ex) { err = ex; }
+    expect(err).to.not.equal(null, "no error thrown");
+    expect(err.message).to.match(/missing issuer or jwks_uri/, "expected missing fields error");
+  });
+
+  it("Discovery failure resets so a later verify can retry", async () => {
+    fakeFetchResponses[0].rsp = { ok: false, status: 502, json: () => Promise.resolve({}) };
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let firstErr: Error | null = null;
+    try { await verifier.verify("any.token"); } catch(ex) { firstErr = ex; }
+    expect(firstErr).to.not.equal(null);
+
+    // Recover discovery and retry — should succeed now.
+    fakeFetchResponses[0].rsp = {
+      ok: true, status: 200,
+      json: () => Promise.resolve({ issuer: ISSUER, jwks_uri: AUTH_URL + "/jwks.json" }),
+    };
+    let token = await mintToken({ email: "alice@example.com" });
+    let claims = await verifier.verify(token);
+    expect(claims.email).to.equal("alice@example.com");
+  });
+
+  it("Strips trailing slashes from authUrl", async () => {
+    let verifier = new AuthenticatoorVerifier(AUTH_URL + "///", AUDIENCE);
+    let token = await mintToken({ email: "alice@example.com" });
+    await verifier.verify(token);
+    let discoveryCall = fakeFetchResponses[0].calls[0];
+    expect(discoveryCall.url).to.equal(AUTH_URL + "/.well-known/openid-configuration",
+      "discovery URL should not have double slashes");
+  });
+});

--- a/tests/modules/AuthenticatoorVerifier.spec.ts
+++ b/tests/modules/AuthenticatoorVerifier.spec.ts
@@ -21,7 +21,7 @@ const AUDIENCE = "faucet.test.local";
 const KID = "test-key-1";
 
 describe("Faucet module: authenticatoor (verifier)", () => {
-  let globalStubs;
+  let globalStubs: any;
   let fakeFetchResponses: IFakeFetchResponse[];
   let privateKey: KeyObject;
   let publicJWK: any;
@@ -127,7 +127,7 @@ describe("Faucet module: authenticatoor (verifier)", () => {
     let err: Error | null = null;
     try { await verifier.verify(token); } catch(ex) { err = ex; }
     expect(err).to.not.equal(null, "no error thrown");
-    expect(err.message.toLowerCase()).to.match(/aud/, "expected aud-related error");
+    expect(err?.message.toLowerCase()).to.match(/aud/, "expected aud-related error");
   });
 
   it("Reject token with wrong issuer", async () => {
@@ -136,7 +136,7 @@ describe("Faucet module: authenticatoor (verifier)", () => {
     let err: Error | null = null;
     try { await verifier.verify(token); } catch(ex) { err = ex; }
     expect(err).to.not.equal(null, "no error thrown");
-    expect(err.message.toLowerCase()).to.match(/iss/, "expected iss-related error");
+    expect(err?.message.toLowerCase()).to.match(/iss/, "expected iss-related error");
   });
 
   it("Reject expired token", async () => {
@@ -145,7 +145,7 @@ describe("Faucet module: authenticatoor (verifier)", () => {
     let err: Error | null = null;
     try { await verifier.verify(token); } catch(ex) { err = ex; }
     expect(err).to.not.equal(null, "no error thrown");
-    expect(err.message.toLowerCase()).to.match(/exp/, "expected exp-related error");
+    expect(err?.message.toLowerCase()).to.match(/exp/, "expected exp-related error");
   });
 
   it("Reject tampered token", async () => {
@@ -155,7 +155,7 @@ describe("Faucet module: authenticatoor (verifier)", () => {
     let err: Error | null = null;
     try { await verifier.verify(tampered); } catch(ex) { err = ex; }
     expect(err).to.not.equal(null, "no error thrown");
-    expect(err.message.toLowerCase()).to.match(/signature/, "expected signature error");
+    expect(err?.message.toLowerCase()).to.match(/signature/, "expected signature error");
   });
 
   it("Reject when discovery endpoint fails", async () => {
@@ -164,7 +164,7 @@ describe("Faucet module: authenticatoor (verifier)", () => {
     let err: Error | null = null;
     try { await verifier.verify("any.token"); } catch(ex) { err = ex; }
     expect(err).to.not.equal(null, "no error thrown");
-    expect(err.message).to.match(/discovery failed: HTTP 502/, "expected discovery http error");
+    expect(err?.message).to.match(/discovery failed: HTTP 502/, "expected discovery http error");
   });
 
   it("Reject when discovery doc is missing fields", async () => {
@@ -173,7 +173,7 @@ describe("Faucet module: authenticatoor (verifier)", () => {
     let err: Error | null = null;
     try { await verifier.verify("any.token"); } catch(ex) { err = ex; }
     expect(err).to.not.equal(null, "no error thrown");
-    expect(err.message).to.match(/missing issuer or jwks_uri/, "expected missing fields error");
+    expect(err?.message).to.match(/missing issuer or jwks_uri/, "expected missing fields error");
   });
 
   it("Discovery failure resets so a later verify can retry", async () => {

--- a/tests/modules/AuthenticatoorVerifier.spec.ts
+++ b/tests/modules/AuthenticatoorVerifier.spec.ts
@@ -5,7 +5,7 @@ import { exportJWK, generateKeyPair, SignJWT, KeyObject } from 'jose';
 import { FetchUtil } from '../../src/utils/FetchUtil.js';
 import { bindTestStubs, unbindTestStubs, loadDefaultTestConfig } from '../common.js';
 import { ServiceManager } from '../../src/common/ServiceManager.js';
-import { AuthenticatoorVerifier } from '../../src/modules/authenticatoor/AuthenticatoorVerifier.js';
+import { AuthenticatoorVerifier, matchHost } from '../../src/modules/authenticatoor/AuthenticatoorVerifier.js';
 
 interface IFakeFetchResponse {
   url: RegExp;
@@ -191,6 +191,73 @@ describe("Faucet module: authenticatoor (verifier)", () => {
     let token = await mintToken({ email: "alice@example.com" });
     let claims = await verifier.verify(token);
     expect(claims.email).to.equal("alice@example.com");
+  });
+
+  it("Scope check: accepts when scope wildcard matches expectedHost", async () => {
+    let token = await mintToken({ email: "alice@example.com", scope: "*.example.com" });
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE, "faucet.example.com");
+    let claims = await verifier.verify(token);
+    expect(claims.email).to.equal("alice@example.com");
+  });
+
+  it("Scope check: rejects when scope wildcard does not match expectedHost", async () => {
+    let token = await mintToken({ email: "alice@example.com", scope: "*.other.com" });
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE, "faucet.example.com");
+    let err: Error | null = null;
+    try { await verifier.verify(token); } catch(ex) { err = ex; }
+    expect(err).to.not.equal(null, "no error thrown");
+    expect(err?.message).to.match(/scope .* does not match host/, "expected scope mismatch error");
+  });
+
+  it("Scope check: tokens without a scope claim are accepted regardless", async () => {
+    let token = await mintToken({ email: "alice@example.com" }); // no scope set
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE, "faucet.example.com");
+    let claims = await verifier.verify(token);
+    expect(claims.email).to.equal("alice@example.com");
+    expect(claims.scope).to.equal(undefined, "scope should be unset on this token");
+  });
+
+  it("Scope check: when expectedHost unset, scope is not checked", async () => {
+    let token = await mintToken({ email: "alice@example.com", scope: "*.totally-different.com" });
+    let verifier = new AuthenticatoorVerifier(AUTH_URL, AUDIENCE);
+    let claims = await verifier.verify(token);
+    expect(claims.email).to.equal("alice@example.com");
+  });
+
+  describe("matchHost", () => {
+    it("exact match", () => {
+      expect(matchHost("foo.bar", "foo.bar")).to.equal(true);
+      expect(matchHost("foo.bar", "baz.bar")).to.equal(false);
+    });
+    it("leading wildcard requires at least one label", () => {
+      expect(matchHost("*.foo.bar", "x.foo.bar")).to.equal(true);
+      expect(matchHost("*.foo.bar", "x.y.foo.bar")).to.equal(true);
+      expect(matchHost("*.foo.bar", "foo.bar")).to.equal(false);
+    });
+    it("label boundary is enforced (no partial wildcard)", () => {
+      expect(matchHost("*.foo.bar", "evil-foo.bar")).to.equal(false);
+    });
+    it("partial wildcards are not supported", () => {
+      expect(matchHost("foo*.bar", "fooz.bar")).to.equal(false);
+    });
+    it("non-leading wildcards are not supported", () => {
+      expect(matchHost("a.*.b", "a.x.b")).to.equal(false);
+      expect(matchHost("a.b.*", "a.b.c")).to.equal(false);
+    });
+    it("'*' alone matches anything", () => {
+      expect(matchHost("*", "anything.example.com")).to.equal(true);
+      expect(matchHost("*", "x")).to.equal(true);
+    });
+    it("case-insensitive", () => {
+      expect(matchHost("*.Example.COM", "Faucet.example.com")).to.equal(true);
+    });
+    it("empty pattern or host returns false", () => {
+      expect(matchHost("", "foo.bar")).to.equal(false);
+      expect(matchHost("foo.bar", "")).to.equal(false);
+    });
+    it("length mismatch on non-wildcard pattern returns false", () => {
+      expect(matchHost("foo.bar", "x.foo.bar")).to.equal(false);
+    });
   });
 
   it("Strips trailing slashes from authUrl", async () => {


### PR DESCRIPTION
# Add authenticatoor authentication module

## Summary

Adds an optional faucet module that integrates with [ethpandaops/service-authenticatoor](https://github.com/ethpandaops/service-authenticatoor) — an HTTP service that issues short-lived RS256 JWTs to users authenticated by an upstream reverse-proxy SSO (Cloudflare Access). This lets faucet operators run a faucet behind their existing SSO and grant authenticated users perks (boosted reward factor, skipped modules, fixed drop amounts) on top of the regular flow.

The module is opt-in. When `requireLogin: false` it runs alongside the existing flow and only kicks in for users who chose to log in. With `requireLogin: true`, sessions cannot be started without a valid token.

## Behavior

**Backend** (`src/modules/authenticatoor/`):
- Discovers the issuer via `<authUrl>/.well-known/openid-configuration` and verifies RS256 JWTs against the published JWKS using `jose`.
- Hooks: `ClientConfig` (prio 1), `SessionStart` (prio 2), `SessionRewardFactor` (prio 5), `SessionComplete` (prio 5).
- Persists `(SessionId, UserId, Issuer)` rows so recurring per-user limits work across sessions.
- Grants follow the zupass model — an array of tiers, each with optional `limitCount` / `limitAmount` over a `duration` window, applying `rewardFactor` / `overrideMaxDrop` / `skipModules` perks. The `required` flag controls whether exhausting a grant throws or silently falls through to the next tier.

**Frontend** (`faucet-client/src/components/frontpage/authenticatoor/`):
- Dynamically loads `<authUrl>/client.js` from the configured authenticatoor and uses its `window.ethpandaops.authenticatoor` API for login/logout/token retrieval.
- Renders a Login button when unauthenticated, or the email + Logout when authenticated, inline in `FaucetInput` next to the address field.
- Submits the cached token as `inputData.authToken` on session start.

## Config

```yaml
modules:
  authenticatoor:
    enabled: true
    authUrl: "https://auth.example.com"
    expectedAudience: "faucet.example.com"
    requireLogin: false
    concurrencyLimit: 0
    grants:
      # baseline: 2x reward for any authenticated user
      - duration: 86400
        rewardFactor: 2

      # 1 free static drop / day, no mining
      - limitCount: 1
        duration: 86400
        skipModules: ["pow", "recurring-limits", "faucet-outflow"]
        overrideMaxDrop: 500000000000000000
    loginLabel: "Login for additional benefits"
    userLabel: "Authenticated"
    infoHtml: |
      <strong>Authenticated users get:</strong><br>
      - 2x reward factor<br>
      - 1 free static drop per day (no mining)
```

`overrideMaxDrop` acts as a true fixed amount only when paired with `skipModules: ["pow"]`. Without skipping pow, it acts as a claim-time cap (the PoW module's prio-10 `setDropAmount(0n)` resets the value otherwise). This matches the existing `voucher` module.

## Files

```
src/modules/authenticatoor/
├── AuthenticatoorConfig.ts      module config + grant interface
├── AuthenticatoorDB.ts          AuthenticatoorSessions table + queries
├── AuthenticatoorModule.ts      hook registrations + grant evaluation
└── AuthenticatoorVerifier.ts    OIDC discovery + JWKS-based JWT verify

faucet-client/src/components/frontpage/authenticatoor/
├── AuthenticatoorLogin.tsx      Login UI, dynamic script injection
└── AuthenticatoorLogin.css

tests/modules/
├── AuthenticatoorModule.spec.ts     22 tests, hook & grant logic
└── AuthenticatoorVerifier.spec.ts   10 tests, JWT verification paths
```

Other touched files:
- `package.json` — adds `jose@^6.2.3` dependency.
- `src/modules/modules.ts` — registers `AuthenticatoorModule`.
- `src/modules/MODULE_HOOKS.md` — documents the new hook priorities.
- `faucet-client/src/common/FaucetConfig.ts` — adds `IAuthenticatoorModuleConfig`.
- `faucet-client/src/components/frontpage/FaucetInput.tsx` — wires the login component into the input panel and submits the token.
- `faucet-config.example.yaml` — annotated example config.

## Tests

32 new tests, all passing. Run with `npm test`.

**Verifier spec** (`AuthenticatoorVerifier.spec.ts`) — generates an RSA keypair via `jose`, stubs `FetchUtil.fetch` to serve a controlled discovery doc + JWKS, mints signed tokens, and verifies the full path:
- valid token → claims extracted (email, sub, iss)
- discovery is cached across multiple verifies
- wrong audience / issuer / expired / tampered → rejected
- discovery HTTP failure → error surfaced; transient failure can be retried
- discovery doc missing fields → clear error
- trailing slashes in `authUrl` are stripped

**Module spec** (`AuthenticatoorModule.spec.ts`) — stubs `AuthenticatoorVerifier.prototype.verify` and exercises every hook through the real `SessionManager` / `ModuleManager` / `FaucetDatabase`:
- client config exports authUrl/labels but not internal fields (grants, audience, concurrency)
- optional vs required login
- invalid token / token without email or sub
- skip.modules entry honored
- valid token applies perks (factor + overrideMaxDrop + skipModules)
- overrideMaxDrop without factor produces exact fixed drop
- rewardFactor flows through SessionRewardFactor hook
- limitCount / limitAmount enforce per-user limits with default and custom messages
- non-required grants fall through silently when exhausted
- concurrencyLimit rejects extra sessions for the same user but not for other users
- SessionComplete persists user→session mapping; no-op without auth data
- DB cleanStore removes orphaned rows
- module loads without verifier when `authUrl` is empty

## Coverage

Project line coverage moved from **93%** → **95.15%**.

| File | Lines | Branch | Funcs |
|---|---|---|---|
| AuthenticatoorConfig.ts | 100% | 100% | 100% |
| AuthenticatoorDB.ts | 100% | 100% | 100% |
| AuthenticatoorModule.ts | 100% | 93.15% | 100% |
| AuthenticatoorVerifier.ts | 100% | 100% | 100% |
| **modules/authenticatoor** | **100%** | **94.89%** | **100%** |

## Manual integration test

Verified end-to-end against a local authenticatoor instance:

```sh
go build -o /tmp/authenticatoor ~/github/ethpandaops/service-authenticatoor/cmd/authenticatoor
/tmp/authenticatoor genkey > /tmp/authtest/key.pem
# config with cloudflareAccess.verifyJWT: false, audience: faucet.local
/tmp/authenticatoor --config /tmp/authtest/config.yaml &

# mint a token
curl -H "Cf-Access-Authenticated-User-Email: alice@example.com" \
     http://127.0.0.1:18080/auth/token

# verifier discovers the issuer, fetches JWKS, and validates the token
node verify-test.mjs
```

Confirmed:
- Discovery doc fetched from `/.well-known/openid-configuration`
- JWKS retrieved and cached
- Real RS256 token verified, claims extracted (email/iss/sub)
- Wrong audience rejected with `unexpected "aud" claim value`
- Tampered token rejected with `signature verification failed`
- `client.js` is fetchable for frontend script injection

## Compatibility

- New module, off by default. Existing operators see no change unless they add an `authenticatoor:` block to their config.
- Adds one runtime dependency (`jose@^6.2.3`).
- Schema additions are confined to a new `AuthenticatoorSessions` table created on first start, with a `cleanStore` migration handler for orphaned-row cleanup.

## Test plan

- [x] `npm test` passes locally (336+ tests; 2 pre-existing MySQL infra failures unrelated to this change)
- [x] `npm run test-coverage` shows ≥ 93% project line coverage
- [x] `npm run build` and `npm run build-client` produce no errors

