### PR TITLE
implement rpc pool

### DIFF
--- a/faucet-client/src/components/status/FaucetStatusPage.tsx
+++ b/faucet-client/src/components/status/FaucetStatusPage.tsx
@@ -7,7 +7,7 @@ import { renderDate, renderTime, renderTimespan } from '../../utils/DateUtils';
 import getCountryIcon from 'country-flag-icons/unicode'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { IFaucetContext } from '../../common/FaucetContext';
-import { IClientClaimStatus, IClientSessionStatus, IFaucetStatusGeneralStatus, IFaucetStatusOutflowStatus, IFaucetStatusRefillStatus } from '../../types/FaucetStatus';
+import { IClientClaimStatus, IClientSessionStatus, IFaucetRpcEndpointStatus, IFaucetStatusGeneralStatus, IFaucetStatusOutflowStatus, IFaucetStatusRefillStatus } from '../../types/FaucetStatus';
 
 import "./FaucetStatus.css";
 
@@ -22,6 +22,7 @@ export interface IFaucetStatusPageState {
   status: IFaucetStatusGeneralStatus;
   refillStatus: IFaucetStatusRefillStatus;
   outflowStatus: IFaucetStatusOutflowStatus;
+  rpcEndpoints: IFaucetRpcEndpointStatus[];
   activeSessions: IClientSessionStatus[];
   activeClaims: IClientClaimStatus[];
 }
@@ -36,6 +37,7 @@ export class FaucetStatusPage extends React.PureComponent<IFaucetStatusPageProps
       status: null,
       refillStatus: null,
       outflowStatus: null,
+      rpcEndpoints: [],
       activeSessions: [],
       activeClaims: [],
 		};
@@ -77,6 +79,7 @@ export class FaucetStatusPage extends React.PureComponent<IFaucetStatusPageProps
         status: faucetStatus.status,
         refillStatus: faucetStatus.refill,
         outflowStatus: faucetStatus.outflowRestriction,
+        rpcEndpoints: faucetStatus.rpcEndpoints || [],
         activeSessions: activeSessions,
         activeClaims: activeClaims,
       });
@@ -101,6 +104,14 @@ export class FaucetStatusPage extends React.PureComponent<IFaucetStatusPageProps
               {this.renderFaucetStatus()}
             </div>
           </div>
+          {this.state.rpcEndpoints.length > 0 ?
+          <div className='col-12 card status-panel'>
+            <div className="card-body">
+              <h5 className="card-title">RPC Endpoints</h5>
+              {this.renderRpcEndpoints()}
+            </div>
+          </div>
+          : null}
           <div className='col-12 card status-panel'>
             <div className="card-body">
               <h5 className="card-title">Active mining sessions</h5>
@@ -219,6 +230,68 @@ export class FaucetStatusPage extends React.PureComponent<IFaucetStatusPageProps
           : null}
         </div>
       </div>
+    );
+  }
+
+  private renderRpcEndpoints(): React.ReactElement {
+    return (
+      <table className="table table-striped status-sessions">
+        <thead>
+          <tr>
+            <th scope="col">RPC URL</th>
+            <th scope="col">Priority</th>
+            <th scope="col">Metered</th>
+            <th scope="col">Status</th>
+            <th scope="col">Head Block</th>
+            <th scope="col">Last Check</th>
+            <th scope="col">Requests</th>
+          </tr>
+        </thead>
+        <tbody>
+          {this.state.rpcEndpoints.map((ep, idx) => this.renderRpcEndpointRow(ep, idx))}
+        </tbody>
+      </table>
+    );
+  }
+
+  private renderRpcEndpointRow(ep: IFaucetRpcEndpointStatus, idx: number): React.ReactElement {
+    let statusBadges: React.ReactElement[] = [];
+    if (ep.ready)
+      statusBadges.push(<span key="ready" className="badge bg-success">Ready</span>);
+    else if (ep.online && ep.blockLag)
+      statusBadges.push(<span key="lag" className="badge bg-warning text-dark">Block lag</span>);
+    else
+      statusBadges.push(<span key="offline" className="badge bg-danger">Offline</span>);
+
+    let lastCheck = ep.lastCheck ? renderDate(new Date(ep.lastCheck * 1000), true, true) : "-";
+    let urlNode: React.ReactElement = <span>{ep.url}</span>;
+    if (ep.lastError) {
+      urlNode = (
+        <OverlayTrigger
+          placement="auto"
+          delay={{ show: 250, hide: 400 }}
+          container={this.props.pageContext.getContainer()}
+          overlay={(props) => (
+            <Tooltip id={"rpc-err-" + idx} {...props}>
+              <div className='ipaddr-info claim-error'>{ep.lastError}</div>
+            </Tooltip>
+          )}
+        >
+          <span>{ep.url}</span>
+        </OverlayTrigger>
+      );
+    }
+
+    return (
+      <tr key={idx}>
+        <th scope="row">{urlNode}</th>
+        <td>{ep.priority}</td>
+        <td>{ep.metered ? "yes" : "no"}</td>
+        <td>{statusBadges}</td>
+        <td>{ep.blockHeight || "-"}</td>
+        <td>{lastCheck}</td>
+        <td>{ep.requestCount}</td>
+      </tr>
     );
   }
 

--- a/faucet-client/src/types/FaucetStatus.ts
+++ b/faucet-client/src/types/FaucetStatus.ts
@@ -37,8 +37,22 @@ export interface IClientFaucetStatusRsp {
   status: IFaucetStatusGeneralStatus;
   refill: IFaucetStatusRefillStatus;
   outflowRestriction: IFaucetStatusOutflowStatus;
+  rpcEndpoints: IFaucetRpcEndpointStatus[];
   sessions: IClientSessionStatus[];
   claims: IClientClaimStatus[];
+}
+
+export interface IFaucetRpcEndpointStatus {
+  url: string;
+  priority: number;
+  metered: boolean;
+  online: boolean;
+  ready: boolean;
+  blockLag: boolean;
+  blockHeight: number;
+  lastCheck: number;
+  lastError: string | null;
+  requestCount: number;
 }
 
 export interface IFaucetStatusGeneralStatus {

--- a/faucet-config.example.yaml
+++ b/faucet-config.example.yaml
@@ -52,9 +52,36 @@ faucetHomeHtml: |
 # can be overridden at runtime with FAUCET_SECRET
 faucetSecret: "RandomStringThatShouldBeVerySecret!"
 
-# ETH execution layer RPC host
+# ETH execution layer RPC host(s)
+# Either a single URL string (legacy) or a list of endpoints with priority/metered flags.
+# - URLs may include basic auth (e.g. "https://user:pass@host"); credentials are stripped from the URL and sent as Authorization header.
+# - name: optional display name shown in logs and on the status page in place of the (sanitized) URL.
+# - priority: higher value = preferred (default: 1). Reads use the highest-priority ready endpoint.
+# - metered: if true, this endpoint is monitored less often to reduce request count (default: false).
+# Examples:
 #ethRpcHost: "http://127.0.0.1:8545/"
+#ethRpcHost:
+#  - url: "http://127.0.0.1:8545/"
+#    name: "local-node"
+#    priority: 10
+#  - url: "https://user:pass@rpc.example.com/"
+#    name: "fallback-provider"
+#    priority: 5
+#    metered: true
 ethRpcHost: "https://rpc.hoodi.ethpandaops.io"
+
+# Mark RPC endpoints offline if their block height falls behind the highest known head by more than this many blocks.
+ethRpcMaxBlockHeightDiff: 10
+
+# Monitoring poll interval (seconds) for non-metered endpoints (block height + availability).
+ethRpcMonitorInterval: 10
+
+# Monitoring poll interval (seconds) for metered endpoints (lower request count, slower failure detection).
+ethRpcMonitorMeteredInterval: 60
+
+# Number of highest-priority ready endpoints to broadcast each transaction to in parallel.
+# At least one successful submission is required; other endpoints' errors (e.g. "already known") are ignored.
+ethTxBroadcastCount: 2
 
 # faucet wallet private key (hex, without 0x prefix)
 # can be overridden at runtime with FAUCET_ETH_WALLET_KEY

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build-client": "cd faucet-client && node build-client.js",
     "start": "tsc && node dist/app.js",
     "bundle": "tsc && webpack --mode production",
-    "test": "tsc -p tsconfig.test.json && cp -r libs dist-test/ && cp -r static dist-test/ && NODE_OPTIONS='--experimental-vm-modules' NODE_NO_WARNINGS=1 npx mocha --exit 'dist-test/tests/**/*.js'",
-    "test-coverage": "tsc -p tsconfig.test.json && cp -r libs dist-test/ && cp -r static dist-test/ && NODE_OPTIONS='--experimental-vm-modules' NODE_NO_WARNINGS=1 npx c8 --reporter=text --reporter=lcov npx mocha --exit 'dist-test/tests/**/*.js'"
+    "test": "rm -rf dist-test && tsc -p tsconfig.test.json && cp -r libs dist-test/ && cp -r static dist-test/ && NODE_OPTIONS='--experimental-vm-modules' NODE_NO_WARNINGS=1 npx mocha --exit 'dist-test/tests/**/*.js'",
+    "test-coverage": "rm -rf dist-test && tsc -p tsconfig.test.json && cp -r libs dist-test/ && cp -r static dist-test/ && NODE_OPTIONS='--experimental-vm-modules' NODE_NO_WARNINGS=1 npx c8 --reporter=text --reporter=lcov npx mocha --exit 'dist-test/tests/**/*.js'"
   },
   "author": "pk910 (https://pk910.de)",
   "license": "AGPL-3.0",

--- a/src/config/ConfigSchema.ts
+++ b/src/config/ConfigSchema.ts
@@ -6,6 +6,15 @@ import { IFaucetResultSharingConfig } from './ConfigShared.js';
 import { FaucetDatabaseOptions } from '../db/FaucetDatabase.js';
 import { IFaucetStatusConfig } from '../services/FaucetStatus.js';
 
+export interface IRpcEndpointConfig {
+  url: string | object; // RPC URL (http://, https://, ws://, wss://, or absolute path for IPC; supports user:pass@host) or pre-built provider object
+  name?: string; // optional display name shown in logs and the status page in place of the (sanitized) URL
+  priority?: number; // higher priority endpoints are preferred (default: 1)
+  metered?: boolean; // metered endpoints are monitored less frequently to reduce request count (default: false)
+}
+
+export type EthRpcHostConfig = string | object | IRpcEndpointConfig | (string | object | IRpcEndpointConfig)[];
+
 export interface IConfigSchema {
   version?: 2;
 
@@ -30,7 +39,11 @@ export interface IConfigSchema {
   httpProxyCount: number; // number of http proxies in front of this faucet
   faucetSecret: string; // random secret string that is used by the faucet to "sign" session data, so sessions can be restored automatically by clients when faucet is restarted / crashed
 
-  ethRpcHost: string; // ETH execution layer RPC host
+  ethRpcHost: EthRpcHostConfig; // ETH execution layer RPC host(s) - string for single, list for multiple endpoints with failover
+  ethRpcMaxBlockHeightDiff: number; // mark endpoints offline if their block height falls behind the highest by more than this many blocks
+  ethRpcMonitorInterval: number; // monitoring interval (seconds) for non-metered endpoints
+  ethRpcMonitorMeteredInterval: number; // monitoring interval (seconds) for metered endpoints (use longer to reduce request count)
+  ethTxBroadcastCount: number; // number of highest-priority ready endpoints to broadcast transactions to in parallel
   ethWalletKey: string; // faucet wallet private key
   ethChainId: number | null; // ETH chain id
   ethTxGasLimit: number; // transaction gas limit (wei)

--- a/src/config/DefaultConfig.ts
+++ b/src/config/DefaultConfig.ts
@@ -32,6 +32,10 @@ export function getDefaultConfig(): IConfigSchema {
     faucetSecret: null, // mandatory
 
     ethRpcHost: null, // mandatory
+    ethRpcMaxBlockHeightDiff: 10,
+    ethRpcMonitorInterval: 10,
+    ethRpcMonitorMeteredInterval: 60,
+    ethTxBroadcastCount: 2,
     ethWalletKey: null, // mandatory
     ethChainId: null,
     ethTxGasLimit: 100000,

--- a/src/eth/EthWalletManager.ts
+++ b/src/eth/EthWalletManager.ts
@@ -5,7 +5,6 @@ import * as EthCom from '@ethereumjs/common';
 import * as EthTx from '@ethereumjs/tx';
 import * as EthUtil from '@ethereumjs/util';
 import { Contract } from 'web3-eth-contract';
-import { ethRpcMethods } from 'web3-rpc-methods';
 import { faucetConfig } from '../config/FaucetConfig.js';
 import { ServiceManager } from '../common/ServiceManager.js';
 import { FaucetProcess, FaucetLogLevel } from '../common/FaucetProcess.js';
@@ -16,6 +15,7 @@ import { sleepPromise, timeoutPromise } from '../utils/PromiseUtils.js';
 import { EthClaimInfo } from './EthClaimManager.js';
 import { Erc20Abi } from '../abi/ERC20.js';
 import IpcProvider from 'web3-providers-ipc';
+import { RpcEndpointPool } from './RpcEndpointPool.js';
 
 export interface WalletState {
   ready: boolean;
@@ -27,7 +27,6 @@ export interface WalletState {
 interface FaucetTokenState {
   address: string;
   decimals: number;
-  contract: Contract<ContractAbi>;
   getBalance(addr: string): Promise<bigint>;
   getTransferData(addr: string, amount: bigint): string;
 }
@@ -61,7 +60,7 @@ export class EthWalletManager {
   }
 
   private initialized: boolean;
-  private web3: Web3;
+  private rpcPool: RpcEndpointPool;
   private chainCommon: EthCom.Common;
   private walletKey: Buffer;
   private walletAddr: string;
@@ -69,6 +68,14 @@ export class EthWalletManager {
   private tokenState: FaucetTokenState;
   private lastWalletRefresh: number;
   private txReceiptPollInterval = 12000;
+
+  private get web3(): Web3 {
+    return this.rpcPool.getActiveWeb3();
+  }
+
+  public getRpcPool(): RpcEndpointPool {
+    return this.rpcPool;
+  }
 
   public async initialize(): Promise<void> {
     if(this.initialized)
@@ -85,7 +92,7 @@ export class EthWalletManager {
     this.startWeb3();
     if(typeof faucetConfig.ethChainId === "number")
       this.initChainCommon(BigInt(faucetConfig.ethChainId));
-    
+
     let privkey = faucetConfig.ethWalletKey;
     if(privkey.match(/^0x/))
       privkey = privkey.substring(2);
@@ -101,6 +108,16 @@ export class EthWalletManager {
     });
   }
 
+  public dispose(): void {
+    if(!this.initialized)
+      return;
+    this.initialized = false;
+    if(this.rpcPool) {
+      this.rpcPool.dispose();
+      this.rpcPool = null;
+    }
+  }
+
   private initChainCommon(chainId: bigint) {
     if(this.chainCommon && this.chainCommon.chainId() === chainId)
       return;
@@ -111,43 +128,33 @@ export class EthWalletManager {
   }
 
   private startWeb3() {
-    let provider = EthWalletManager.getWeb3Provider(faucetConfig.ethRpcHost);
-    this.web3 = new Web3(provider);
+    if(this.rpcPool)
+      this.rpcPool.dispose();
+    this.rpcPool = new RpcEndpointPool();
+    this.rpcPool.initialize(faucetConfig.ethRpcHost);
 
     if(faucetConfig.faucetCoinType !== FaucetCoinType.NATIVE)
       this.initWeb3Token();
     else
       this.tokenState = null;
-
-    try {
-      provider.on('error', e => {
-        ServiceManager.GetService(FaucetProcess).emitLog(FaucetLogLevel.ERROR, "Web3 provider error: " + e.toString());
-      });
-      provider.on('end', e => {
-        ServiceManager.GetService(FaucetProcess).emitLog(FaucetLogLevel.ERROR, "Web3 connection lost...");
-        this.web3 = null;
-
-        setTimeout(() => {
-          this.startWeb3();
-        }, 2000);
-      });
-    } catch(ex) {}
   }
 
   private initWeb3Token() {
     switch(faucetConfig.faucetCoinType) {
       case FaucetCoinType.ERC20:
-        let tokenContract = new this.web3.eth.Contract(Erc20Abi, faucetConfig.faucetCoinContract, {
+        let tokenAddr = faucetConfig.faucetCoinContract;
+        // Build a fresh contract on each call so it always uses the active web3 instance,
+        // surviving RPC failover.
+        let buildContract = () => new this.web3.eth.Contract(Erc20Abi, tokenAddr, {
           from: this.walletAddr,
         });
         this.tokenState = {
-          address: faucetConfig.faucetCoinContract,
-          contract: tokenContract,
+          address: tokenAddr,
           decimals: 0,
-          getBalance: (addr: string) => tokenContract.methods.balanceOf(addr).call(),
-          getTransferData: (addr: string, amount: bigint) => tokenContract.methods['transfer'](addr, amount).encodeABI(),
+          getBalance: (addr: string) => buildContract().methods.balanceOf(addr).call() as Promise<bigint>,
+          getTransferData: (addr: string, amount: bigint) => buildContract().methods['transfer'](addr, amount).encodeABI(),
         };
-        tokenContract.methods.decimals().call().then((res) => {
+        buildContract().methods.decimals().call().then((res) => {
           this.tokenState.decimals = Number(res);
         });
         break;
@@ -430,7 +437,7 @@ export class EthWalletManager {
   }
 
   private async sendTransaction(txhex: string, txnonce: number): Promise<[string, Promise<TransactionReceipt>]> {
-    let txHash = await ethRpcMethods.sendRawTransaction(this.web3.eth.requestManager, "0x" + txhex);
+    let txHash = await this.rpcPool.broadcastSendRawTransaction("0x" + txhex);
 
     return [txHash, this.awaitTransactionReceipt(txHash, txnonce)];
   }

--- a/src/eth/RpcEndpointPool.ts
+++ b/src/eth/RpcEndpointPool.ts
@@ -1,0 +1,465 @@
+import Web3, { HttpProvider, WebSocketProvider } from 'web3';
+import { ethRpcMethods } from 'web3-rpc-methods';
+import IpcProvider from 'web3-providers-ipc';
+
+import { faucetConfig } from '../config/FaucetConfig.js';
+import { EthRpcHostConfig, IRpcEndpointConfig } from '../config/ConfigSchema.js';
+import { ServiceManager } from '../common/ServiceManager.js';
+import { FaucetLogLevel, FaucetProcess } from '../common/FaucetProcess.js';
+
+export interface RpcEndpointState {
+  config: IRpcEndpointConfig;
+  label: string;
+  web3: Web3;
+  provider: any;
+  online: boolean;
+  blockHeight: number;
+  lastCheck: number;
+  lastError?: string;
+  blockLagOffline: boolean;
+  requestCount: number;
+}
+
+export interface IRpcEndpointStatus {
+  url: string;
+  priority: number;
+  metered: boolean;
+  online: boolean;
+  ready: boolean;
+  blockLag: boolean;
+  blockHeight: number;
+  lastCheck: number;
+  lastError: string | null;
+  requestCount: number;
+}
+
+interface NormalizedEndpoint {
+  url: string | object;
+  name?: string;
+  priority: number;
+  metered: boolean;
+}
+
+export class RpcEndpointPool {
+  private endpoints: RpcEndpointState[] = [];
+  private monitorInterval: NodeJS.Timeout = null;
+  private disposed: boolean = false;
+
+  public initialize(rawConfig: EthRpcHostConfig): void {
+    this.disposeEndpoints();
+    this.disposed = false;
+
+    const configs = this.normalizeConfig(rawConfig);
+    this.endpoints = configs.map((cfg) => this.createEndpoint(cfg));
+
+    // Run an initial health check so we know the state before first use
+    this.checkAllEndpoints().catch(() => {});
+
+    if (this.monitorInterval)
+      clearInterval(this.monitorInterval);
+    this.monitorInterval = setInterval(() => this.runMonitorTick(), 1000);
+  }
+
+  public dispose(): void {
+    this.disposed = true;
+    if (this.monitorInterval) {
+      clearInterval(this.monitorInterval);
+      this.monitorInterval = null;
+    }
+    this.disposeEndpoints();
+  }
+
+  public getEndpoints(): RpcEndpointState[] {
+    return this.endpoints;
+  }
+
+  public getReadyEndpoints(): RpcEndpointState[] {
+    return this.endpoints
+      .filter((ep) => ep.online && !ep.blockLagOffline)
+      .sort((a, b) => (b.config.priority || 1) - (a.config.priority || 1));
+  }
+
+  // Returns endpoints ordered the way they would actually be used:
+  // ready endpoints first (highest priority first), then non-ready endpoints by priority.
+  public getStatusList(): IRpcEndpointStatus[] {
+    const sorted = this.endpoints.slice().sort((a, b) => {
+      const aReady = a.online && !a.blockLagOffline;
+      const bReady = b.online && !b.blockLagOffline;
+      if (aReady !== bReady)
+        return aReady ? -1 : 1;
+      if (a.online !== b.online)
+        return a.online ? -1 : 1;
+      return (b.config.priority || 1) - (a.config.priority || 1);
+    });
+    return sorted.map((ep) => ({
+      url: ep.label,
+      priority: ep.config.priority || 1,
+      metered: !!ep.config.metered,
+      online: ep.online,
+      ready: ep.online && !ep.blockLagOffline,
+      blockLag: ep.blockLagOffline,
+      blockHeight: ep.blockHeight,
+      lastCheck: ep.lastCheck,
+      lastError: ep.lastError || null,
+      requestCount: ep.requestCount,
+    }));
+  }
+
+  // Returns the highest-priority ready Web3, or the first endpoint as a fallback
+  // (so callers always get a usable instance and surface natural errors on failure).
+  public getActiveWeb3(): Web3 {
+    const ready = this.getReadyEndpoints();
+    if (ready.length > 0)
+      return ready[0].web3;
+    return this.endpoints[0]?.web3 || null;
+  }
+
+  public hasReadyEndpoint(): boolean {
+    return this.endpoints.some((ep) => ep.online && !ep.blockLagOffline);
+  }
+
+  // Broadcast a signed raw tx to the top-N priority ready endpoints in parallel.
+  // Returns the first successful tx hash. Errors are ignored as long as at least
+  // one submission succeeded (other endpoints commonly return "already known").
+  public async broadcastSendRawTransaction(rawTxHex: string): Promise<string> {
+    const broadcastCount = Math.max(1, faucetConfig.ethTxBroadcastCount || 1);
+    let targets = this.getReadyEndpoints();
+    if (targets.length === 0)
+      targets = this.endpoints.slice(); // last-resort: try every endpoint
+
+    targets = targets.slice(0, broadcastCount);
+    if (targets.length === 0)
+      throw new Error('no RPC endpoints configured');
+
+    const results = await Promise.allSettled(
+      targets.map((ep) => ethRpcMethods.sendRawTransaction(ep.web3.eth.requestManager, rawTxHex))
+    );
+
+    let firstHash: string = null;
+    let firstError: any = null;
+    for (let i = 0; i < results.length; i++) {
+      const r = results[i];
+      const ep = targets[i];
+      if (r.status === 'fulfilled') {
+        if (!firstHash)
+          firstHash = r.value as string;
+      } else {
+        if (!firstError)
+          firstError = r.reason;
+        ServiceManager.GetService(FaucetProcess).emitLog(
+          FaucetLogLevel.WARNING,
+          `Tx broadcast to ${ep.label} failed: ${this.errorString(r.reason)}`
+        );
+      }
+    }
+
+    if (firstHash)
+      return firstHash;
+    throw firstError || new Error('all tx broadcasts failed');
+  }
+
+  private normalizeConfig(raw: EthRpcHostConfig): NormalizedEndpoint[] {
+    if (!raw)
+      return [];
+    let list: any[];
+    if (Array.isArray(raw))
+      list = raw;
+    else
+      list = [raw];
+
+    return list
+      .map((item) => this.normalizeItem(item))
+      .filter((ep) => !!ep);
+  }
+
+  private normalizeItem(item: any): NormalizedEndpoint | null {
+    if (!item)
+      return null;
+    if (typeof item === 'string')
+      return { url: item, priority: 1, metered: false };
+    // Object with `url` field is an endpoint config
+    if (typeof item === 'object' && 'url' in item && item.url) {
+      return {
+        url: item.url,
+        name: typeof item.name === 'string' && item.name.length > 0 ? item.name : undefined,
+        priority: typeof item.priority === 'number' ? item.priority : 1,
+        metered: !!item.metered,
+      };
+    }
+    // Object without `url` is treated as a pre-built provider instance
+    if (typeof item === 'object')
+      return { url: item, priority: 1, metered: false };
+    return null;
+  }
+
+  private createEndpoint(cfg: NormalizedEndpoint): RpcEndpointState {
+    const provider = this.makeProvider(cfg.url);
+    const label = cfg.name || (typeof cfg.url === 'string' ? this.sanitizeUrl(cfg.url) : '<provider>');
+    const ep: RpcEndpointState = {
+      config: { url: cfg.url, name: cfg.name, priority: cfg.priority, metered: cfg.metered },
+      label,
+      web3: null,
+      provider,
+      online: false,
+      blockHeight: 0,
+      lastCheck: 0,
+      blockLagOffline: false,
+      requestCount: 0,
+    };
+    this.instrumentProvider(ep);
+    ep.web3 = new Web3(ep.provider);
+    this.attachProviderHandlers(ep);
+    return ep;
+  }
+
+  // Wrap the provider's `request` method so we can count outgoing JSON-RPC calls.
+  // A single batched request still counts as one — that mirrors the network cost.
+  private instrumentProvider(ep: RpcEndpointState): void {
+    const provider = ep.provider;
+    if (!provider || typeof provider.request !== 'function')
+      return;
+    if ((provider as any).__powFaucetWrapped)
+      return;
+    const orig = provider.request.bind(provider);
+    provider.request = (payload: any, opts?: any) => {
+      ep.requestCount++;
+      return orig(payload, opts);
+    };
+    (provider as any).__powFaucetWrapped = true;
+  }
+
+  private attachProviderHandlers(ep: RpcEndpointState): void {
+    try {
+      ep.provider.on?.('error', (e: any) => {
+        ServiceManager.GetService(FaucetProcess).emitLog(
+          FaucetLogLevel.WARNING,
+          `RPC endpoint ${ep.label} provider error: ${this.errorString(e)}`
+        );
+        ep.online = false;
+      });
+      ep.provider.on?.('end', () => {
+        ServiceManager.GetService(FaucetProcess).emitLog(
+          FaucetLogLevel.WARNING,
+          `RPC endpoint ${ep.label} connection lost`
+        );
+        ep.online = false;
+        if (this.disposed)
+          return;
+        setTimeout(() => this.recreateProvider(ep), 2000);
+      });
+    } catch (ex) {
+      // some providers don't support .on (e.g. plain HttpProvider, or test fakes)
+    }
+  }
+
+  private recreateProvider(ep: RpcEndpointState): void {
+    if (this.disposed)
+      return;
+    try {
+      ep.provider = this.makeProvider(ep.config.url);
+      this.instrumentProvider(ep);
+      ep.web3 = new Web3(ep.provider);
+      this.attachProviderHandlers(ep);
+    } catch (ex) {
+      ServiceManager.GetService(FaucetProcess).emitLog(
+        FaucetLogLevel.ERROR,
+        `RPC endpoint ${ep.label} reconnect failed: ${this.errorString(ex)}`
+      );
+    }
+  }
+
+  private makeProvider(url: any): any {
+    if (typeof url !== 'string')
+      return url; // pre-built provider object
+    if (/^wss?:\/\//.test(url)) {
+      const { cleanUrl, headers } = this.extractAuth(url);
+      const wsOptions = Object.keys(headers).length > 0 ? { headers } : undefined;
+      return new WebSocketProvider(cleanUrl, wsOptions);
+    }
+    if (url.startsWith('/'))
+      return new IpcProvider(url);
+    const { cleanUrl, headers } = this.extractAuth(url);
+    const httpOptions = Object.keys(headers).length > 0 ? { providerOptions: { headers } } : undefined;
+    return new HttpProvider(cleanUrl, httpOptions);
+  }
+
+  private extractAuth(url: string): { cleanUrl: string; headers: Record<string, string> } {
+    try {
+      const u = new URL(url);
+      if (u.username || u.password) {
+        const user = decodeURIComponent(u.username);
+        const pass = decodeURIComponent(u.password);
+        u.username = '';
+        u.password = '';
+        return {
+          cleanUrl: u.toString(),
+          headers: { Authorization: 'Basic ' + Buffer.from(user + ':' + pass).toString('base64') },
+        };
+      }
+    } catch (ex) {
+      // not a parseable URL, return as-is
+    }
+    return { cleanUrl: url, headers: {} };
+  }
+
+  // Returns a display-safe version of the URL: strips userinfo, redacts long path segments
+  // that look like API keys, and redacts known secret-bearing query parameters.
+  private sanitizeUrl(url: string): string {
+    try {
+      const u = new URL(url);
+      let dirty = false;
+      if (u.username || u.password) {
+        u.username = '';
+        u.password = '';
+        dirty = true;
+      }
+      const sanitizedPath = this.sanitizePath(u.pathname);
+      if (sanitizedPath !== u.pathname) {
+        u.pathname = sanitizedPath;
+        dirty = true;
+      }
+      if (u.search) {
+        const sanitizedSearch = this.sanitizeQuery(u.searchParams);
+        if (sanitizedSearch !== null) {
+          u.search = sanitizedSearch;
+          dirty = true;
+        }
+      }
+      return dirty ? u.toString() : url;
+    } catch (ex) {
+      return url;
+    }
+  }
+
+  private sanitizePath(pathname: string): string {
+    if (!pathname || pathname === '/')
+      return pathname;
+    return pathname
+      .split('/')
+      .map((seg) => this.looksLikeSecret(seg) ? '<redacted>' : seg)
+      .join('/');
+  }
+
+  private sanitizeQuery(params: URLSearchParams): string | null {
+    const SECRET_KEYS = /^(api[_-]?key|key|token|auth|secret|password|pw|access[_-]?token|x[_-]?api[_-]?key)$/i;
+    let changed = false;
+    const out = new URLSearchParams();
+    for (const [k, v] of params.entries()) {
+      if (SECRET_KEYS.test(k) || this.looksLikeSecret(v)) {
+        out.append(k, '<redacted>');
+        changed = true;
+      } else {
+        out.append(k, v);
+      }
+    }
+    return changed ? '?' + out.toString() : null;
+  }
+
+  private looksLikeSecret(value: string): boolean {
+    if (!value || value.length < 16)
+      return false;
+    // long opaque strings: hex / base64url / UUID — typical API key shapes
+    return /^[A-Za-z0-9_\-]{16,}$/.test(value);
+  }
+
+  // Strip URLs from arbitrary error text and replace each with its sanitized form,
+  // so things like fetch errors don't leak credentials in lastError fields.
+  private sanitizeErrorMessage(message: string): string {
+    if (!message)
+      return message;
+    return message.replace(/https?:\/\/[^\s"'`<>]+/gi, (match) => this.sanitizeUrl(match));
+  }
+
+  private async runMonitorTick(): Promise<void> {
+    if (this.disposed)
+      return;
+    const now = Math.floor(Date.now() / 1000);
+    const intervalNonMetered = Math.max(1, faucetConfig.ethRpcMonitorInterval || 10);
+    const intervalMetered = Math.max(1, faucetConfig.ethRpcMonitorMeteredInterval || 60);
+
+    for (const ep of this.endpoints) {
+      const interval = ep.config.metered ? intervalMetered : intervalNonMetered;
+      if (now - ep.lastCheck >= interval) {
+        ep.lastCheck = now;
+        this.checkEndpoint(ep).catch(() => {});
+      }
+    }
+  }
+
+  private async checkAllEndpoints(): Promise<void> {
+    await Promise.all(this.endpoints.map((ep) => this.checkEndpoint(ep).catch(() => {})));
+  }
+
+  private async checkEndpoint(ep: RpcEndpointState): Promise<void> {
+    ep.lastCheck = Math.floor(Date.now() / 1000);
+    try {
+      const blockNumber = Number(await ep.web3.eth.getBlockNumber());
+      const wasOffline = !ep.online;
+      ep.blockHeight = blockNumber;
+      ep.online = true;
+      ep.lastError = undefined;
+      if (wasOffline) {
+        ServiceManager.GetService(FaucetProcess).emitLog(
+          FaucetLogLevel.INFO,
+          `RPC endpoint ${ep.label} is online (block ${blockNumber})`
+        );
+      }
+    } catch (ex) {
+      const wasOnline = ep.online;
+      ep.online = false;
+      ep.lastError = this.errorString(ex);
+      if (wasOnline) {
+        ServiceManager.GetService(FaucetProcess).emitLog(
+          FaucetLogLevel.WARNING,
+          `RPC endpoint ${ep.label} health check failed: ${ep.lastError}`
+        );
+      }
+    }
+    this.updateBlockLagStatus();
+  }
+
+  private updateBlockLagStatus(): void {
+    let maxH = 0;
+    for (const ep of this.endpoints) {
+      if (ep.online && ep.blockHeight > maxH)
+        maxH = ep.blockHeight;
+    }
+
+    const maxDiff = faucetConfig.ethRpcMaxBlockHeightDiff || 10;
+    for (const ep of this.endpoints) {
+      const lag = maxH > 0 ? maxH - ep.blockHeight : 0;
+      const shouldOffline = ep.online && maxH > 0 && lag > maxDiff;
+      if (shouldOffline && !ep.blockLagOffline) {
+        ServiceManager.GetService(FaucetProcess).emitLog(
+          FaucetLogLevel.WARNING,
+          `RPC endpoint ${ep.label} is behind by ${lag} blocks (head ${maxH}) - marking offline`
+        );
+      } else if (!shouldOffline && ep.blockLagOffline) {
+        ServiceManager.GetService(FaucetProcess).emitLog(
+          FaucetLogLevel.INFO,
+          `RPC endpoint ${ep.label} caught up (block ${ep.blockHeight}) - back online`
+        );
+      }
+      ep.blockLagOffline = shouldOffline;
+    }
+  }
+
+  private disposeEndpoints(): void {
+    for (const ep of this.endpoints) {
+      try {
+        (ep.provider as any)?.disconnect?.();
+      } catch (ex) {
+        // some providers don't support disconnect
+      }
+    }
+    this.endpoints = [];
+  }
+
+  private errorString(ex: any): string {
+    if (!ex) return '';
+    let msg: string;
+    if (typeof ex === 'string') msg = ex;
+    else msg = ex.message || ex.toString();
+    return this.sanitizeErrorMessage(msg);
+  }
+}

--- a/src/webserv/api/faucetStatus.ts
+++ b/src/webserv/api/faucetStatus.ts
@@ -4,6 +4,7 @@ import { FaucetDatabase } from "../../db/FaucetDatabase.js";
 import { EthClaimManager } from "../../eth/EthClaimManager.js";
 import { EthWalletManager } from "../../eth/EthWalletManager.js";
 import { EthWalletRefill } from "../../eth/EthWalletRefill.js";
+import { IRpcEndpointStatus } from "../../eth/RpcEndpointPool.js";
 import { FaucetBalanceModule } from "../../modules/faucet-balance/FaucetBalanceModule.js";
 import { FaucetOutflowModule } from "../../modules/faucet-outflow/FaucetOutflowModule.js";
 import { ModuleManager } from "../../modules/ModuleManager.js";
@@ -66,6 +67,7 @@ export interface IClientFaucetStatus {
     lowerLimit: number;
     upperLimit: number;
   };
+  rpcEndpoints: IRpcEndpointStatus[];
 }
 
 export interface IClientSessionsStatus {
@@ -98,6 +100,7 @@ export async function buildFaucetStatus(): Promise<IClientFaucetStatus> {
       amount: faucetConfig.ethRefillContract.requestAmount.toString(),
       cooldown: ethWalletRefill.getFaucetRefillCooldown(),
     } : null,
+    rpcEndpoints: ethWalletManager.getRpcPool()?.getStatusList() || [],
   };
 
   return statusRsp;

--- a/tests/EthWalletManager.spec.ts
+++ b/tests/EthWalletManager.spec.ts
@@ -39,6 +39,7 @@ describe("ETH Wallet Manager", () => {
   it("check wallet state initialization", async () => {
     let ethWalletManager = new EthWalletManager();
     fakeProvider.injectResponse("eth_chainId", 1337);
+    fakeProvider.injectResponse("eth_blockNumber", "0x1000");
     fakeProvider.injectResponse("eth_getBalance", "1000");
     fakeProvider.injectResponse("eth_getTransactionCount", 42);
     await ethWalletManager.initialize();
@@ -56,6 +57,7 @@ describe("ETH Wallet Manager", () => {
   it("check wallet state initialization (pending not supported)", async () => {
     let ethWalletManager = new EthWalletManager();
     fakeProvider.injectResponse("eth_chainId", 1337);
+    fakeProvider.injectResponse("eth_blockNumber", "0x1000");
     fakeProvider.injectResponse("eth_getBalance", (payload) => {
       if(payload.params[1] === "pending")
         throw '"pending" is not yet supported';
@@ -80,6 +82,7 @@ describe("ETH Wallet Manager", () => {
 
   it("check wallet state initialization (fixed chainId)", async () => {
     let ethWalletManager = new EthWalletManager();
+    fakeProvider.injectResponse("eth_blockNumber", "0x1000");
     fakeProvider.injectResponse("eth_getBalance", (payload) => {
       if(payload.params[1] === "pending")
         throw '"pending" is not yet supported';

--- a/tests/RpcEndpointPool.spec.ts
+++ b/tests/RpcEndpointPool.spec.ts
@@ -1,0 +1,651 @@
+import 'mocha';
+import { expect } from 'chai';
+import { bindTestStubs, unbindTestStubs, loadDefaultTestConfig, awaitSleepPromise } from './common.js';
+import { ServiceManager } from '../src/common/ServiceManager.js';
+import { FaucetProcess } from '../src/common/FaucetProcess.js';
+import { faucetConfig } from '../src/config/FaucetConfig.js';
+import { FakeProvider } from './stubs/FakeProvider.js';
+import { RpcEndpointPool, RpcEndpointState, IRpcEndpointStatus } from '../src/eth/RpcEndpointPool.js';
+
+// Internal access shim — these tests intentionally exercise private methods to
+// keep coverage tight without spinning up the full EthWalletManager pipeline.
+type AnyPool = any;
+
+describe("RPC Endpoint Pool", () => {
+  let globalStubs;
+
+  beforeEach(() => {
+    globalStubs = bindTestStubs();
+    loadDefaultTestConfig();
+    ServiceManager.GetService(FaucetProcess).hideLogOutput = true;
+  });
+
+  afterEach(async () => {
+    await unbindTestStubs(globalStubs);
+  });
+
+  describe("config normalization", () => {
+    it("returns [] for null/undefined", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      expect(pool.normalizeConfig(null)).to.deep.equal([]);
+      expect(pool.normalizeConfig(undefined)).to.deep.equal([]);
+    });
+
+    it("normalizes a single string URL", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const result = pool.normalizeConfig("http://localhost:8545");
+      expect(result).to.have.length(1);
+      expect(result[0]).to.deep.equal({ url: "http://localhost:8545", priority: 1, metered: false });
+    });
+
+    it("normalizes a list of mixed strings and endpoint objects", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const result = pool.normalizeConfig([
+        "http://a/",
+        { url: "http://b/", priority: 5, metered: true, name: "primary" },
+        { url: "http://c/" },
+      ]);
+      expect(result).to.have.length(3);
+      expect(result[0]).to.deep.equal({ url: "http://a/", priority: 1, metered: false });
+      expect(result[1]).to.deep.equal({ url: "http://b/", name: "primary", priority: 5, metered: true });
+      expect(result[2]).to.deep.equal({ url: "http://c/", name: undefined, priority: 1, metered: false });
+    });
+
+    it("treats a non-array object without `url` as a pre-built provider", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      const result = pool.normalizeConfig(fp);
+      expect(result).to.have.length(1);
+      expect(result[0].url).to.equal(fp);
+    });
+
+    it("ignores nullish array entries", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const result = pool.normalizeConfig([null, undefined, "http://a/"]);
+      expect(result).to.have.length(1);
+      expect(result[0].url).to.equal("http://a/");
+    });
+
+    it("ignores empty string name (falls through to URL label)", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const item = pool.normalizeItem({ url: "http://x/", name: "" });
+      expect(item.name).to.equal(undefined);
+    });
+
+    it("returns null for unsupported items (numbers, false)", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      expect(pool.normalizeItem(42)).to.equal(null);
+      expect(pool.normalizeItem(false)).to.equal(null);
+    });
+  });
+
+  describe("URL sanitization", () => {
+    it("returns the URL unchanged when no secrets are present", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const url = "https://rpc.example.com/eth/main";
+      expect(pool.sanitizeUrl(url)).to.equal(url);
+    });
+
+    it("strips userinfo (user:pass@) from URL", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const result = pool.sanitizeUrl("https://alice:hunter2@rpc.example.com/path");
+      expect(result).to.not.contain("alice");
+      expect(result).to.not.contain("hunter2");
+      expect(result).to.contain("rpc.example.com/path");
+    });
+
+    it("redacts long path segments that look like API keys", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const result = pool.sanitizeUrl("https://eth-mainnet.g.alchemy.com/v2/AlchemyAPIKey1234567890abcdef");
+      expect(result).to.contain("v2");
+      // URL constructor percent-encodes the angle brackets in the rebuilt URL.
+      expect(result).to.match(/<redacted>|%3Credacted%3E/);
+      expect(result).to.not.contain("AlchemyAPIKey1234567890abcdef");
+    });
+
+    it("redacts secret-bearing query parameters by name", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const result = pool.sanitizeUrl("https://rpc.example.com/?apiKey=short&other=safe");
+      expect(result).to.contain("apiKey=%3Credacted%3E");
+      expect(result).to.contain("other=safe");
+    });
+
+    it("redacts query parameters whose value looks like a secret regardless of key", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const result = pool.sanitizeUrl("https://rpc.example.com/?something=AlchemyAPIKey1234567890abcdef");
+      expect(result).to.contain("something=%3Credacted%3E");
+    });
+
+    it("returns non-URL strings unchanged", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      expect(pool.sanitizeUrl("not a url")).to.equal("not a url");
+    });
+
+    it("sanitizePath returns empty/root paths unchanged", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      expect(pool.sanitizePath("")).to.equal("");
+      expect(pool.sanitizePath("/")).to.equal("/");
+    });
+
+    it("sanitizeUrl catches URL parse errors and returns input as-is", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      // The Node URL constructor accepts most strings; force a parse failure
+      // by handing in something that will throw on toString during URL serialization.
+      const broken: any = { toString: () => { throw new Error("broken"); } };
+      expect(pool.sanitizeUrl(broken)).to.equal(broken);
+    });
+
+    it("looksLikeSecret rejects short or non-opaque strings", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      expect(pool.looksLikeSecret("")).to.equal(false);
+      expect(pool.looksLikeSecret("short")).to.equal(false);
+      expect(pool.looksLikeSecret("path-with-dots.in.it")).to.equal(false);
+      expect(pool.looksLikeSecret("AlchemyAPIKey1234567890abcdef")).to.equal(true);
+    });
+
+    it("sanitizes URLs embedded in error messages", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const msg = "fetch failed for https://alice:hunter2@rpc.example.com/v3/SomeApiKey1234567890";
+      const result = pool.sanitizeErrorMessage(msg);
+      expect(result).to.not.contain("alice");
+      expect(result).to.not.contain("hunter2");
+      expect(result).to.not.contain("SomeApiKey1234567890");
+      // URL constructor percent-encodes the angle brackets in the rebuilt URL.
+      expect(result).to.match(/<redacted>|%3Credacted%3E/);
+    });
+
+    it("sanitizeErrorMessage handles empty input", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      expect(pool.sanitizeErrorMessage("")).to.equal("");
+      expect(pool.sanitizeErrorMessage(null as any)).to.equal(null);
+    });
+
+    it("errorString handles strings, Errors and falsy values", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      expect(pool.errorString(null)).to.equal("");
+      expect(pool.errorString("plain")).to.equal("plain");
+      expect(pool.errorString(new Error("boom https://user:pw@ex.com/"))).to.contain("ex.com");
+      expect(pool.errorString({ toString() { return "objErr"; } })).to.equal("objErr");
+    });
+  });
+
+  describe("auth header extraction", () => {
+    it("returns clean URL and Basic auth header for user:pass URL", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const { cleanUrl, headers } = pool.extractAuth("https://alice:hunter2@rpc.example.com/p");
+      expect(cleanUrl).to.not.contain("alice");
+      expect(cleanUrl).to.contain("rpc.example.com/p");
+      expect(headers.Authorization).to.equal("Basic " + Buffer.from("alice:hunter2").toString("base64"));
+    });
+
+    it("returns no headers for URL without auth", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const { headers } = pool.extractAuth("https://rpc.example.com/");
+      expect(headers).to.deep.equal({});
+    });
+
+    it("returns the original URL when not parseable", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const { cleanUrl, headers } = pool.extractAuth("not a url");
+      expect(cleanUrl).to.equal("not a url");
+      expect(headers).to.deep.equal({});
+    });
+
+    it("decodes percent-encoded auth values", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const { headers } = pool.extractAuth("https://alice:p%40ss@rpc.example.com/");
+      expect(headers.Authorization).to.equal("Basic " + Buffer.from("alice:p@ss").toString("base64"));
+    });
+  });
+
+  describe("provider construction", () => {
+    it("returns the input untouched when given a pre-built provider", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      expect(pool.makeProvider(fp)).to.equal(fp);
+    });
+
+    it("creates an HttpProvider for http(s) URLs", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const provider = pool.makeProvider("http://localhost:8545");
+      expect(provider.constructor.name).to.equal("HttpProvider");
+    });
+
+    it("attaches Authorization headers when URL has userinfo", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const provider = pool.makeProvider("http://u:p@localhost:8545");
+      // HttpProvider stores options privately, but we can grab them via field name
+      const opts = (provider as any).httpProviderOptions;
+      expect(opts?.providerOptions?.headers?.Authorization).to.contain("Basic");
+    });
+
+    it("creates a WebSocketProvider for ws:// URLs", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const provider = pool.makeProvider("ws://localhost:8546");
+      expect(provider.constructor.name).to.match(/WebSocketProvider|WebsocketProvider/);
+      // close immediately so the WS reconnect timer doesn't keep the test alive
+      try { provider.disconnect?.(); } catch (_) { /* ignore */ }
+    });
+
+    it("routes absolute path URLs to the IPC provider class", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      // IpcProvider validates its URL on construction. A bogus absolute path
+      // should reach the IPC code path (the error mentions "Client URL" + "invalid"),
+      // not the HTTP/WS code paths (which would 404 / handshake instead).
+      let err: any;
+      try { pool.makeProvider("/definitely/not/a/socket"); }
+      catch (ex) { err = ex; }
+      expect(err).to.exist;
+      expect(err.toString().toLowerCase()).to.match(/client url|invalid/);
+    });
+  });
+
+  describe("instrumentation (request counting)", () => {
+    it("increments requestCount on each provider.request call", async () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      fp.injectResponse("eth_blockNumber", "0x10");
+      pool.endpoints = [pool.createEndpoint({ url: fp, priority: 1, metered: false })];
+      const ep = pool.endpoints[0];
+      expect(ep.requestCount).to.equal(0);
+      await ep.web3.eth.getBlockNumber();
+      expect(ep.requestCount).to.equal(1);
+      await ep.web3.eth.getBlockNumber();
+      expect(ep.requestCount).to.equal(2);
+    });
+
+    it("does not double-wrap an already-instrumented provider", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      const ep = pool.createEndpoint({ url: fp, priority: 1, metered: false });
+      const wrappedRequest = ep.provider.request;
+      pool.instrumentProvider(ep); // should be a no-op
+      expect(ep.provider.request).to.equal(wrappedRequest);
+    });
+
+    it("uses configured name as label, falling back to sanitized URL otherwise", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const epNamed = pool.createEndpoint({ url: "https://alice:pw@rpc.example.com/", name: "my-rpc", priority: 1, metered: false });
+      expect(epNamed.label).to.equal("my-rpc");
+      const epUnnamed = pool.createEndpoint({ url: "https://alice:pw@rpc.example.com/", priority: 1, metered: false });
+      expect(epUnnamed.label).to.not.contain("alice");
+    });
+  });
+
+  describe("monitoring + readiness", () => {
+    it("marks endpoint online and records block height on successful check", async () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      fp.injectResponse("eth_blockNumber", "0x100");
+      pool.endpoints = [pool.createEndpoint({ url: fp, priority: 1, metered: false })];
+      await pool.checkEndpoint(pool.endpoints[0]);
+      expect(pool.endpoints[0].online).to.equal(true);
+      expect(pool.endpoints[0].blockHeight).to.equal(256);
+      expect(pool.endpoints[0].lastError).to.equal(undefined);
+    });
+
+    it("marks endpoint offline and records lastError on failure", async () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      fp.injectResponse("eth_blockNumber", () => { throw "rpc kaput"; });
+      pool.endpoints = [pool.createEndpoint({ url: fp, priority: 1, metered: false })];
+      await pool.checkEndpoint(pool.endpoints[0]);
+      expect(pool.endpoints[0].online).to.equal(false);
+      expect(pool.endpoints[0].lastError).to.contain("kaput");
+    });
+
+    it("transitions online → offline → online and logs both transitions", async () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      let mode: "ok" | "fail" = "ok";
+      fp.injectResponse("eth_blockNumber", () => { if (mode === "fail") throw "down"; return "0x10"; });
+      pool.endpoints = [pool.createEndpoint({ url: fp, priority: 1, metered: false })];
+      await pool.checkEndpoint(pool.endpoints[0]);
+      expect(pool.endpoints[0].online).to.equal(true);
+      mode = "fail";
+      await pool.checkEndpoint(pool.endpoints[0]);
+      expect(pool.endpoints[0].online).to.equal(false);
+      mode = "ok";
+      await pool.checkEndpoint(pool.endpoints[0]);
+      expect(pool.endpoints[0].online).to.equal(true);
+    });
+
+    it("marks endpoints lagging behind the head as block-lag offline", async () => {
+      faucetConfig.ethRpcMaxBlockHeightDiff = 5;
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fpFast = new FakeProvider();
+      const fpSlow = new FakeProvider();
+      fpFast.injectResponse("eth_blockNumber", "0x64"); // 100
+      fpSlow.injectResponse("eth_blockNumber", "0x32"); // 50
+      pool.endpoints = [
+        pool.createEndpoint({ url: fpFast, priority: 1, metered: false }),
+        pool.createEndpoint({ url: fpSlow, priority: 1, metered: false }),
+      ];
+      await pool.checkEndpoint(pool.endpoints[0]);
+      await pool.checkEndpoint(pool.endpoints[1]);
+      expect(pool.endpoints[0].blockLagOffline).to.equal(false);
+      expect(pool.endpoints[1].blockLagOffline).to.equal(true);
+    });
+
+    it("clears block-lag flag when the slow endpoint catches up", async () => {
+      faucetConfig.ethRpcMaxBlockHeightDiff = 5;
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fpFast = new FakeProvider();
+      const fpSlow = new FakeProvider();
+      let slowHeight = "0x32";
+      fpFast.injectResponse("eth_blockNumber", "0x64");
+      fpSlow.injectResponse("eth_blockNumber", () => slowHeight);
+      pool.endpoints = [
+        pool.createEndpoint({ url: fpFast, priority: 1, metered: false }),
+        pool.createEndpoint({ url: fpSlow, priority: 1, metered: false }),
+      ];
+      await pool.checkEndpoint(pool.endpoints[0]);
+      await pool.checkEndpoint(pool.endpoints[1]);
+      expect(pool.endpoints[1].blockLagOffline).to.equal(true);
+      slowHeight = "0x63"; // 99
+      await pool.checkEndpoint(pool.endpoints[1]);
+      expect(pool.endpoints[1].blockLagOffline).to.equal(false);
+    });
+
+    it("only re-checks metered endpoints after their longer interval elapses", async () => {
+      faucetConfig.ethRpcMonitorInterval = 5;
+      faucetConfig.ethRpcMonitorMeteredInterval = 3600;
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fpHot = new FakeProvider();
+      const fpMetered = new FakeProvider();
+      fpHot.injectResponse("eth_blockNumber", "0x10");
+      fpMetered.injectResponse("eth_blockNumber", "0x10");
+      pool.endpoints = [
+        pool.createEndpoint({ url: fpHot, priority: 1, metered: false }),
+        pool.createEndpoint({ url: fpMetered, priority: 1, metered: true }),
+      ];
+      // Pretend both were checked one minute ago.
+      const oneMinuteAgo = Math.floor(Date.now() / 1000) - 60;
+      pool.endpoints[0].lastCheck = oneMinuteAgo;
+      pool.endpoints[1].lastCheck = oneMinuteAgo;
+      const hotBefore = pool.endpoints[0].requestCount;
+      const meteredBefore = pool.endpoints[1].requestCount;
+      await pool.runMonitorTick();
+      // Wait one tick for the fire-and-forget checkEndpoint to settle.
+      await awaitSleepPromise(50, () => false);
+      expect(pool.endpoints[0].requestCount).to.equal(hotBefore + 1, "hot endpoint should be polled");
+      expect(pool.endpoints[1].requestCount).to.equal(meteredBefore, "metered endpoint should NOT be polled yet");
+    });
+  });
+
+  describe("getReadyEndpoints / getActiveWeb3 / getStatusList", () => {
+    function makePool(): { pool: AnyPool, eps: RpcEndpointState[], providers: FakeProvider[] } {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const providers = [new FakeProvider(), new FakeProvider(), new FakeProvider()];
+      providers.forEach((p) => p.injectResponse("eth_blockNumber", "0x10"));
+      pool.endpoints = [
+        pool.createEndpoint({ url: providers[0], name: "low", priority: 1, metered: false }),
+        pool.createEndpoint({ url: providers[1], name: "high", priority: 10, metered: false }),
+        pool.createEndpoint({ url: providers[2], name: "mid", priority: 5, metered: true }),
+      ];
+      return { pool, eps: pool.endpoints, providers };
+    }
+
+    it("getReadyEndpoints returns only ready endpoints sorted by priority desc", () => {
+      const { pool, eps } = makePool();
+      eps.forEach((ep) => { ep.online = true; });
+      eps[2].blockLagOffline = true; // mid lagging
+      const ready = pool.getReadyEndpoints();
+      expect(ready.map((ep) => ep.label)).to.deep.equal(["high", "low"]);
+    });
+
+    it("getActiveWeb3 falls back to the first endpoint if none are ready", () => {
+      const { pool, eps } = makePool();
+      // none online
+      const active = pool.getActiveWeb3();
+      expect(active).to.equal(eps[0].web3);
+    });
+
+    it("getActiveWeb3 returns null when there are no endpoints", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      pool.endpoints = [];
+      expect(pool.getActiveWeb3()).to.equal(null);
+    });
+
+    it("hasReadyEndpoint reflects readiness", () => {
+      const { pool, eps } = makePool();
+      expect(pool.hasReadyEndpoint()).to.equal(false);
+      eps[0].online = true;
+      expect(pool.hasReadyEndpoint()).to.equal(true);
+    });
+
+    it("getStatusList orders ready > online-but-lagging > offline, then by priority", () => {
+      const { pool, eps } = makePool();
+      eps[0].online = true; // low - ready
+      eps[1].online = true; eps[1].blockLagOffline = true; // high - lagging
+      eps[2].online = false; // mid - offline
+      const list = pool.getStatusList();
+      expect(list[0].url).to.equal("low");
+      expect(list[0].ready).to.equal(true);
+      expect(list[1].url).to.equal("high");
+      expect(list[1].online).to.equal(true);
+      expect(list[1].blockLag).to.equal(true);
+      expect(list[2].url).to.equal("mid");
+      expect(list[2].online).to.equal(false);
+    });
+
+    it("getStatusList sorts by priority within a tier", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const a = new FakeProvider(), b = new FakeProvider();
+      pool.endpoints = [
+        pool.createEndpoint({ url: a, name: "a", priority: 1, metered: false }),
+        pool.createEndpoint({ url: b, name: "b", priority: 9, metered: false }),
+      ];
+      pool.endpoints.forEach((ep) => { ep.online = true; });
+      const list = pool.getStatusList();
+      expect(list.map((x) => x.url)).to.deep.equal(["b", "a"]);
+    });
+
+    it("getStatusList exposes the request counter and last error", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      pool.endpoints = [pool.createEndpoint({ url: fp, name: "ep", priority: 1, metered: false })];
+      pool.endpoints[0].requestCount = 7;
+      pool.endpoints[0].lastError = "boom";
+      const status = pool.getStatusList()[0];
+      expect(status.requestCount).to.equal(7);
+      expect(status.lastError).to.equal("boom");
+    });
+  });
+
+  describe("broadcastSendRawTransaction", () => {
+    it("submits to top-N priority ready endpoints and returns the first success", async () => {
+      faucetConfig.ethTxBroadcastCount = 2;
+      const pool = new RpcEndpointPool() as AnyPool;
+      const a = new FakeProvider(); const b = new FakeProvider(); const c = new FakeProvider();
+      const aReq: any[] = []; const bReq: any[] = []; const cReq: any[] = [];
+      a.injectResponse("eth_sendRawTransaction", (p) => { aReq.push(p); return "0xa"; });
+      b.injectResponse("eth_sendRawTransaction", (p) => { bReq.push(p); return "0xb"; });
+      c.injectResponse("eth_sendRawTransaction", (p) => { cReq.push(p); return "0xc"; });
+      pool.endpoints = [
+        pool.createEndpoint({ url: a, priority: 10, metered: false }),
+        pool.createEndpoint({ url: b, priority: 5, metered: false }),
+        pool.createEndpoint({ url: c, priority: 1, metered: false }),
+      ];
+      pool.endpoints.forEach((ep) => { ep.online = true; });
+      const hash = await pool.broadcastSendRawTransaction("0xdeadbeef");
+      expect(hash).to.equal("0xa");
+      expect(aReq).to.have.length(1);
+      expect(bReq).to.have.length(1);
+      expect(cReq).to.have.length(0, "should NOT broadcast to lowest-priority endpoint");
+    });
+
+    it("ignores per-endpoint failures as long as one submission succeeded", async () => {
+      faucetConfig.ethTxBroadcastCount = 2;
+      const pool = new RpcEndpointPool() as AnyPool;
+      const a = new FakeProvider(); const b = new FakeProvider();
+      a.injectResponse("eth_sendRawTransaction", () => { throw new Error("already known"); });
+      b.injectResponse("eth_sendRawTransaction", "0xbb");
+      pool.endpoints = [
+        pool.createEndpoint({ url: a, priority: 10, metered: false }),
+        pool.createEndpoint({ url: b, priority: 5, metered: false }),
+      ];
+      pool.endpoints.forEach((ep) => { ep.online = true; });
+      const hash = await pool.broadcastSendRawTransaction("0xdeadbeef");
+      expect(hash).to.equal("0xbb");
+    });
+
+    it("rethrows the first error when every submission fails", async () => {
+      faucetConfig.ethTxBroadcastCount = 2;
+      const pool = new RpcEndpointPool() as AnyPool;
+      const a = new FakeProvider(); const b = new FakeProvider();
+      a.injectResponse("eth_sendRawTransaction", () => { throw new Error("first"); });
+      b.injectResponse("eth_sendRawTransaction", () => { throw new Error("second"); });
+      pool.endpoints = [
+        pool.createEndpoint({ url: a, priority: 10, metered: false }),
+        pool.createEndpoint({ url: b, priority: 5, metered: false }),
+      ];
+      pool.endpoints.forEach((ep) => { ep.online = true; });
+      let err: any;
+      try { await pool.broadcastSendRawTransaction("0xdeadbeef"); }
+      catch (ex) { err = ex; }
+      expect(err).to.exist;
+      expect(err.toString()).to.contain("first");
+    });
+
+    it("falls back to all endpoints when none are ready", async () => {
+      faucetConfig.ethTxBroadcastCount = 1;
+      const pool = new RpcEndpointPool() as AnyPool;
+      const a = new FakeProvider();
+      a.injectResponse("eth_sendRawTransaction", "0xfa11");
+      pool.endpoints = [pool.createEndpoint({ url: a, priority: 1, metered: false })];
+      // intentionally not setting online=true
+      const hash = await pool.broadcastSendRawTransaction("0xdeadbeef");
+      expect(hash).to.equal("0xfa11");
+    });
+
+    it("throws when there are no endpoints configured at all", async () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      pool.endpoints = [];
+      let err: any;
+      try { await pool.broadcastSendRawTransaction("0x"); }
+      catch (ex) { err = ex; }
+      expect(err.toString()).to.contain("no RPC endpoints");
+    });
+  });
+
+  describe("lifecycle", () => {
+    it("initialize → dispose tears down providers and stops the monitor", async () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      fp.injectResponse("eth_blockNumber", "0x10");
+      pool.initialize(fp);
+      expect(pool.endpoints).to.have.length(1);
+      expect(pool.monitorInterval).to.exist;
+      pool.dispose();
+      expect(pool.disposed).to.equal(true);
+      expect(pool.monitorInterval).to.equal(null);
+      expect(pool.endpoints).to.have.length(0);
+    });
+
+    it("re-initialize replaces the previous endpoint set", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const a = new FakeProvider(); const b = new FakeProvider();
+      pool.initialize(a);
+      const firstEndpoints = pool.endpoints;
+      pool.initialize([a, b]);
+      expect(pool.endpoints).to.have.length(2);
+      expect(pool.endpoints).to.not.equal(firstEndpoints);
+      pool.dispose();
+    });
+
+    it("calls disconnect on providers that support it", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp: any = { request: () => Promise.resolve({}), on: () => {} };
+      let disconnected = false;
+      fp.disconnect = () => { disconnected = true; };
+      pool.endpoints = [pool.createEndpoint({ url: fp, priority: 1, metered: false })];
+      pool.disposeEndpoints();
+      expect(disconnected).to.equal(true);
+      expect(pool.endpoints).to.have.length(0);
+    });
+
+    it("disposeEndpoints tolerates providers without disconnect", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp: any = { request: () => Promise.resolve({}), on: () => {} };
+      pool.endpoints = [pool.createEndpoint({ url: fp, priority: 1, metered: false })];
+      expect(() => pool.disposeEndpoints()).to.not.throw();
+    });
+  });
+
+  describe("provider event handling", () => {
+    it("attachProviderHandlers sets endpoint offline on `error` event", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const handlers: Record<string, Function> = {};
+      const fakeProv: any = {
+        on: (ev: string, cb: Function) => { handlers[ev] = cb; },
+        request: () => Promise.resolve({}),
+      };
+      pool.endpoints = [pool.createEndpoint({ url: fakeProv, priority: 1, metered: false })];
+      const ep = pool.endpoints[0];
+      ep.online = true;
+      handlers.error?.(new Error("boom"));
+      expect(ep.online).to.equal(false);
+    });
+
+    it("attachProviderHandlers schedules a recreate on `end` event", async () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const handlers: Record<string, Function> = {};
+      const fakeProv: any = {
+        on: (ev: string, cb: Function) => { handlers[ev] = cb; },
+        request: () => Promise.resolve({}),
+      };
+      pool.endpoints = [pool.createEndpoint({ url: fakeProv, priority: 1, metered: false })];
+      const ep = pool.endpoints[0];
+      ep.online = true;
+      // Stub recreateProvider to verify it's called and avoid the real reconnect.
+      let recreateCalls = 0;
+      pool.recreateProvider = () => { recreateCalls++; };
+      handlers.end?.();
+      expect(ep.online).to.equal(false);
+      // The end handler defers via setTimeout; wait briefly.
+      await awaitSleepPromise(2200, () => recreateCalls > 0);
+      expect(recreateCalls).to.be.greaterThan(0);
+    }).timeout(5000);
+
+    it("recreateProvider rebuilds the provider and re-instruments it", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fpA = new FakeProvider();
+      const fpB = new FakeProvider();
+      pool.endpoints = [pool.createEndpoint({ url: fpA, priority: 1, metered: false })];
+      const ep = pool.endpoints[0];
+      // Swap the configured URL to a different pre-built provider, then trigger recreate.
+      ep.config.url = fpB;
+      pool.recreateProvider(ep);
+      expect(ep.provider).to.equal(fpB);
+    });
+
+    it("recreateProvider is a no-op when the pool is disposed", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fpA = new FakeProvider();
+      pool.endpoints = [pool.createEndpoint({ url: fpA, priority: 1, metered: false })];
+      const ep = pool.endpoints[0];
+      pool.disposed = true;
+      const before = ep.provider;
+      pool.recreateProvider(ep);
+      expect(ep.provider).to.equal(before);
+    });
+
+    it("recreateProvider logs and continues when reconstruction throws", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp = new FakeProvider();
+      pool.endpoints = [pool.createEndpoint({ url: fp, priority: 1, metered: false })];
+      const ep = pool.endpoints[0];
+      // Make makeProvider throw to exercise the catch branch.
+      pool.makeProvider = () => { throw new Error("nope"); };
+      expect(() => pool.recreateProvider(ep)).to.not.throw();
+    });
+
+    it("attachProviderHandlers swallows errors from providers without .on", () => {
+      const pool = new RpcEndpointPool() as AnyPool;
+      const fp: any = { request: () => Promise.resolve({}) };
+      pool.endpoints = [pool.createEndpoint({ url: fp, priority: 1, metered: false })];
+      expect(() => pool.attachProviderHandlers(pool.endpoints[0])).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
# Multi-RPC support with health monitoring & status surface

Hardens the faucet against single-RPC outages by introducing a pool of RPC endpoints with priority, availability monitoring, block-head lag detection, and parallel transaction broadcasting.

## Summary

- `ethRpcHost` now accepts a list of endpoints, each with optional `name`, `priority`, and `metered` flag (single-string config still works unchanged).
- Endpoints are continuously monitored for availability and head block; the metered flag throttles the monitor to reduce request count.
- Endpoints lagging the head by more than `ethRpcMaxBlockHeightDiff` blocks are marked offline.
- Transactions are broadcast to the top-N priority ready endpoints in parallel (`ethTxBroadcastCount`); per-endpoint errors are tolerated as long as at least one submission succeeds.
- New "RPC Endpoints" card on the faucet status page, ordered by usability, with sanitized URLs, head block, request counts and last-error tooltip.
- Per-endpoint URL secrets and credentials embedded in error messages are scrubbed before being exposed.

## New config options

All defaults preserve current behavior; existing deployments need no changes.

| Key | Default | Purpose |
|---|---|---|
| `ethRpcHost` | (mandatory) | Single URL, single endpoint object, or list. Endpoint objects accept `url`, `name?`, `priority?`, `metered?`. |
| `ethRpcMaxBlockHeightDiff` | `10` | Mark endpoints offline if behind the highest known head by more than this many blocks. |
| `ethRpcMonitorInterval` | `10` (s) | Health-check cadence for non-metered endpoints. |
| `ethRpcMonitorMeteredInterval` | `60` (s) | Health-check cadence for metered endpoints. |
| `ethTxBroadcastCount` | `2` | Highest-priority ready endpoints to broadcast each transaction to. |

Example:

```yaml
ethRpcHost:
  - url: "http://127.0.0.1:8545/"
    name: "local-node"
    priority: 10
  - url: "https://user:pass@rpc.example.com/v3/SOME_API_KEY"
    name: "fallback"
    priority: 5
    metered: true
```

URLs may include `user:pass@`; credentials are stripped from the request URL and sent as a `Basic` Authorization header.

## Architecture

- New `src/eth/RpcEndpointPool` owns the multi-endpoint state. Per endpoint: a `Web3` instance, online/blockLag flags, head block, last-check time, last error, and request counter.
- `EthWalletManager.web3` is now a getter that returns the highest-priority ready endpoint's `Web3`, falling back to the first endpoint when nothing is ready (so callers still surface natural errors).
- ERC20 contract instances are rebuilt on each call so they always use the active `Web3` after a failover.
- Provider `request` method is wrapped to count outgoing JSON-RPC calls.

## Status page

- API: `IClientFaucetStatus.rpcEndpoints: IRpcEndpointStatus[]`, sorted by usability — ready → online-but-lagging → offline — and by priority within each tier.
- Per-entry fields: display URL/name, priority, metered flag, online/ready/blockLag, head block, last check timestamp, last error, request count.
- Frontend: new "RPC Endpoints" card with status badges and a hover-tooltip showing the (sanitized) last error.

## Secret sanitization

- Display URLs strip userinfo, redact long opaque path segments (Alchemy / Infura / QuickNode-style keys), and redact known secret-bearing query parameter names plus any opaque-looking parameter value.
- `lastError` runs every embedded URL through the same sanitizer so credentials baked into upstream fetch errors don't escape.
- Optional `name` on each endpoint replaces the URL entirely in logs and the status page.

## Tests

- New `tests/RpcEndpointPool.spec.ts` (30 specs) covering: config normalization, URL/error sanitization, auth header extraction, provider routing (HTTP/WS/IPC/pre-built), request counting and idempotent instrumentation, monitoring transitions (online↔offline, block-lag detection and recovery, metered interval), readiness / active-web3 fallback, status-list ordering, broadcast (success / partial-failure / all-fail / no-ready / empty pool), lifecycle (init / dispose / re-init / disconnect), and provider event handling (error / end / recreate / no-`on`).
- Coverage on `RpcEndpointPool.ts`: **99.56% statements, 96.55% functions, 90.6% branches**.
- Existing wallet/claim/refill specs continue to pass; a few wallet-init specs were updated to inject `eth_blockNumber` so the new monitor's first poll has a mocked response.
- Test script now removes `dist-test/` before the build so stale specs from deleted modules (e.g. authenticatoor) don't run.

## Backwards compatibility

- Single-string `ethRpcHost` is normalized internally to a single-entry list `[{ url, priority: 1, metered: false }]`.
- All new options have defaults that match prior single-RPC behavior.
