### PR TITLE
Fix invalid static request URLs when DISABLE_NGINX=1

### DIFF
--- a/src/webserv/FaucetHttpServer.ts
+++ b/src/webserv/FaucetHttpServer.ts
@@ -139,7 +139,13 @@ export class FaucetHttpServer {
                 this.staticServer.serveFile("/index.html", 200, {}, req, rsp);
               break;
             default:
-              let pathname = decodeURI(new URL(req.url, 'http://localhost').pathname);
+              let pathname: string;
+              try {
+                pathname = decodeURI(new URL(req.url, 'http://localhost').pathname);
+              } catch {
+                this.sendApiResponse(req, rsp, 400, "Bad Request", {}, "");
+                return;
+              }
               this.staticServer.servePath(pathname, 200, this.getCorsHeaders(req), req, rsp, (status, headers) => {
                 if(!rsp.headersSent && !rsp.writableEnded) {
                   rsp.writeHead(status, headers);

--- a/tests/FaucetHttpServer.spec.ts
+++ b/tests/FaucetHttpServer.spec.ts
@@ -93,6 +93,19 @@ describe("Faucet Web Server", () => {
     expect(indexData).contains("<!-- pow-faucet-header -->", "not index contents");
   });
 
+  it("rejects invalid static request urls without crashing", async () => {
+    faucetConfig.faucetTitle = "test_title_" + Math.floor(Math.random() * 99999999).toString();
+    faucetConfig.buildSeoIndex = false;
+    faucetConfig.serverPort = 0;
+    let webServer = ServiceManager.GetService(FaucetHttpServer);
+    webServer.initialize();
+    await returnDelayedPromise(true, null);
+    let listenPort = webServer.getListenPort();
+    let response = await FetchUtil.fetch("http://localhost:" + listenPort + "//", {method: "GET"});
+    expect(response.status).equals(400, "unexpected response status");
+    expect(response.statusText).equals("Bad Request", "unexpected response status text");
+  });
+
   it("check api call (GET)", async () => {
     faucetConfig.faucetTitle = "test_title_" + Math.floor(Math.random() * 99999999).toString();
     faucetConfig.buildSeoIndex = false;


### PR DESCRIPTION
This fixes a crash in PoWFaucet's built-in static file server when `DISABLE_NGINX=1`.

A request target like `//` makes `new URL()` throw while the faucet is resolving the static file path. The exception escapes the request handler and is picked up by PoWFaucet's `uncaughtException` handler, which shuts the process down with exit code 1 instead of returning an HTTP response.

This change:
- returns `400 Bad Request` when the static request URL cannot be parsed
- keeps normal static file requests unchanged
- adds a regression test for the `//` request