### PR TITLE
fix: pre-fill address input from ?address= query parameter

### DIFF
--- a/faucet-client/src/components/frontpage/FrontPage.tsx
+++ b/faucet-client/src/components/frontpage/FrontPage.tsx
@@ -12,6 +12,7 @@ export interface IFrontPageProps {
   faucetContext: IFaucetContext;
   faucetConfig: IFaucetConfig;
   navigateFn: NavigateFunction;
+  defaultAddr?: string;
 }
 
 export interface IFrontPageState {
@@ -97,6 +98,7 @@ export class FrontPage extends React.PureComponent<IFrontPageProps, IFrontPageSt
           ref={this.faucetInput} 
           faucetContext={this.props.faucetContext} 
           faucetConfig={this.props.faucetConfig} 
+          defaultAddr={this.props.defaultAddr}
           submitInputs={(inputData) => this.onSubmitInputs(inputData)}/>
         
         <div className='faucet-description'>
@@ -220,12 +222,16 @@ export class FrontPage extends React.PureComponent<IFrontPageProps, IFrontPageSt
 }
 
 export default (props) => {
+  const searchParams = new URLSearchParams(window.location.search);
+  const addressParam = searchParams.get('address');
+
   return (
     <FrontPage 
       {...props}
       faucetContext={useContext(FaucetPageContext)}
       faucetConfig={useContext(FaucetConfigContext)}
       navigateFn={useNavigate()}
+      defaultAddr={addressParam || undefined}
     />
   );
 };


### PR DESCRIPTION
The address input field was not being pre-filled when visiting the faucet with `?address=0x...` in the URL.

`FaucetInput` already accepted a `defaultAddr` prop and used it in its constructor, but `FrontPage` never extracted `?address=` from the URL to pass it through.

**Changes:**
- Added `defaultAddr?: string` to `IFrontPageProps`
- `FrontPage.render()` now forwards `defaultAddr` to `<FaucetInput>`
- The default export wrapper reads `?address=` from `window.location.search` and passes it as `defaultAddr`

This allows link-sharing like `https://faucet.example.com/?address=0x...` to pre-fill the target address so users can click and immediately start mining.