### PR TITLE
Raise default ethTxGasLimit to cover new-account state-creation gas

### DIFF
--- a/src/config/DefaultConfig.ts
+++ b/src/config/DefaultConfig.ts
@@ -38,7 +38,7 @@ export function getDefaultConfig(): IConfigSchema {
     ethTxBroadcastCount: 2,
     ethWalletKey: null, // mandatory
     ethChainId: null,
-    ethTxGasLimit: 100000,
+    ethTxGasLimit: 250000, // must cover new-account state-creation gas (~207k on EIP-8037 chains)
     ethLegacyTx: false,
     ethTxMaxFee: 100000000000,
     ethTxPrioFee: 2000000000,


### PR DESCRIPTION
## Problem

On chains that have activated **EIP-8037 (state-creation gas)** — e.g. Ethereum's Glamsterdam devnets — a faucet drop **reverts with out-of-gas for every fresh recipient address**.

A drop is a plain value transfer, and when the recipient account does not yet exist, the transfer *creates* it. EIP-8037 charges `STATE_BYTES_PER_NEW_ACCOUNT (120) × CPSB (1530) = 183,600` extra state-creation gas for that, on top of the usual ~21,000. So a first-time drop now costs **~207,000 gas**.

`ethTxGasLimit` defaults to `100000`, which used to be plenty (a new-account transfer was 21,000 pre-fork) but is now too low. Result: the tx consumes its full 100,000 limit and reverts, delivering nothing. Only *repeat* drops to already-funded addresses succeed — which defeats the faucet.

### Evidence (glamsterdam-devnet-6)

```
reverted drop tx: value 100 ETH, gas limit 100000, gasUsed 100000/100000, status 0x0, recipient balance 0
eth_estimateGas(faucet -> new empty account) = 207,391   (identical on geth/besu/ethrex)
eth_estimateGas(faucet -> existing account)   = ~21,000
```

## Fix

Raise the default `ethTxGasLimit` from `100000` to `250000` (~20% headroom over the measured 207k). Unused gas is refunded, so this does **not** increase the fee paid for successful transactions — it only needs to be reserved.

This is the minimal immediate fix. A more durable follow-up would be to `estimateGas` per drop in `buildEthTx` (falling back to `ethTxGasLimit` as a floor) so the faucet auto-adapts to future repricings; happy to send that separately if preferred.